### PR TITLE
fix: v5.1 bug fixes - Photos Library size and npm cache display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to MacCleans.sh are documented in this file.
 
+## [5.1] - 2026-03-21
+
+### Bug Fixes
+
+- **Photos Library size calculation** - Fixed size reporting to only measure cache subdirectories (Thumbnails, Previews, etc.) instead of entire library, resolving 38GB vs 7GB discrepancy
+- **npm cache size formatting** - Fixed size display showing "211B" instead of "211M" by using consistent byte calculation
+
+### Technical
+
+- Version bumped: 5.0 → 5.1
+
 ## [5.0] - 2026-03-20
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
      ⚡  MacCleans  ⚡
-           v5.0
+           v5.1
 
 Free 10-50GB on your Mac with one command.
 
-[![Version](https://img.shields.io/badge/Version-5.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-5.1-blue.svg)](CHANGELOG.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![macOS](https://img.shields.io/badge/macOS-10.15+-blue.svg)](https://www.apple.com/macos/)
 [![Stars](https://img.shields.io/github/stars/Carme99/MacCleans.sh?style=social)](https://github.com/Carme99/MacCleans.sh/stargazers)
@@ -140,6 +140,11 @@ chmod +x /usr/local/bin/Mac-Clean
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Contributing |
 
 ---
+
+## What's New in v5.1
+
+- **Photos Library Fix** - Size calculation now only measures cache (Thumbnails, Previews) instead of entire library
+- **npm Cache Fix** - Size display now correctly shows "211M" instead of "211B"
 
 ## What's New in v5.0
 

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -3,7 +3,7 @@
 # Enable strict error handling
 set -euo pipefail
 
-VERSION="5.0"
+VERSION="5.1"
 
 ###############################################################################
 # Mac-Clean: macOS Disk Cleanup Utility
@@ -1847,10 +1847,11 @@ if [ "$SKIP_NPM" = false ]; then
     # npm cache
     NPM_CACHE="$USER_HOME/.npm"
     if [ -d "$NPM_CACHE" ]; then
-        NPM_SIZE=$(du -sh "$NPM_CACHE" 2>/dev/null | awk '{print $1}' || echo "0B")
-        if [ -n "$NPM_SIZE" ] && [ "$NPM_SIZE" != "0B" ]; then
+        NPM_KB=$(du -sk "$NPM_CACHE" 2>/dev/null | awk '{print $1}' || echo "0")
+        NPM_BYTES=$((NPM_KB * 1024))
+        if [ "$NPM_BYTES" -gt 0 ]; then
+            NPM_SIZE=$(bytes_to_human "$NPM_BYTES")
             log "npm cache: $NPM_SIZE"
-            NPM_BYTES=$(size_to_bytes "$NPM_SIZE")
             NODE_TOTAL_BYTES=$((NODE_TOTAL_BYTES + NPM_BYTES))
 
             if [ "$DRY_RUN" = false ]; then
@@ -2315,7 +2316,15 @@ if [ "$SKIP_PHOTOS_LIBRARY" = false ]; then
                 fi
 
                 if [ -d "$RESOURCES_DIR" ]; then
-                    LIB_KB=$(du -sk "$RESOURCES_DIR" 2>/dev/null | awk '{print $1}' || echo "0")
+                    CACHE_SIZE_KB=0
+                    for cache_dir in derivatives renders caches proxies; do
+                        target="$RESOURCES_DIR/$cache_dir"
+                        if [ -d "$target" ] && [ ! -L "$target" ]; then
+                            dir_size=$(du -sk "$target" 2>/dev/null | awk '{print $1}' || echo "0")
+                            CACHE_SIZE_KB=$((CACHE_SIZE_KB + dir_size))
+                        fi
+                    done
+                    LIB_KB=$CACHE_SIZE_KB
                     
                     if [ "$LIB_KB" -gt 0 ]; then
                         LIB_HUMAN=$(bytes_to_human $((LIB_KB * 1024)))


### PR DESCRIPTION
## Summary

v5.1 patch release with bug fixes.

### Bug Fixes

- **Photos Library size calculation** - Now only measures cache subdirectories (Thumbnails, Previews, etc.) instead of entire library
- **npm cache size formatting** - Fixed "211B" display issue, now correctly shows "211M"

### Changes

- Version: 5.0 → 5.1
- README and CHANGELOG updated

## Summary by Sourcery

Release v5.1 with corrected disk usage reporting for npm cache and Photos Library caches, plus updated documentation and version metadata.

Bug Fixes:
- Correct npm cache size calculation and human-readable formatting to avoid misreporting very small sizes.
- Adjust Photos Library size calculation to only account for cache-related subdirectories instead of the entire library, preventing over-reporting of usage.

Enhancements:
- Bump script version constant from 5.0 to 5.1 to reflect the new patch release.

Documentation:
- Update README with v5.1 version badge and a “What’s New in v5.1” section describing the fixes.
- Document v5.1 changes and fixes in the CHANGELOG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Photos Library size calculation to more accurately measure only relevant cache data, resolving previously reported size discrepancies.
  * Fixed npm cache size display formatting to correctly convert and display size units (e.g., showing "211M" instead of "211B").

* **Version**
  * Updated to version 5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->