### PR TITLE
fix: resolve tmutil snapshot count integer expression error (v5.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to MacCleans.sh are documented in this file.
 
+## [5.1.1] - 2026-03-28
+
+### Bug Fixes
+
+- **Time Machine snapshot count error** - Fixed `[: 0\n0: integer expression expected]` error when no Time Machine snapshots exist by using explicit exit code check instead of `|| echo "0"` fallback
+
 ## [5.1] - 2026-03-21
 
 ### Bug Fixes

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -1437,7 +1437,11 @@ if [ "$SKIP_SNAPSHOTS" = false ]; then
         log_warning "Time Machine backup is currently running"
         log "Skipping snapshot deletion for safety"
     else
-        SNAPSHOTS=$(tmutil listlocalsnapshots / 2>/dev/null | grep -c "com.apple.TimeMachine" || echo "0")
+        SNAPSHOTS=$(tmutil listlocalsnapshots / 2>/dev/null | grep -c "com.apple.TimeMachine")
+        rc=$?
+        if [ $rc -ne 0 ]; then
+            SNAPSHOTS=0
+        fi
         if [ "$SNAPSHOTS" -gt 0 ]; then
             # Note: macOS doesn't expose snapshot sizes directly
             # Only showing count as accurate size calculation isn't possible


### PR DESCRIPTION
## Summary
- Fix `[: 0\n0: integer expression expected]` error when no Time Machine snapshots exist
- Use explicit exit code check instead of `|| echo "0"` fallback
- Updated CHANGELOG.md for v5.1.1

## Bug Details
The error occurred at line 1440 when `tmutil listlocalsnapshots` returned no output. The `grep -c` combined with the `|| echo "0"` fallback caused an integer expression error in the subsequent test.

## Testing
- [x] Script passes `bash -n` syntax check
- [x] ShellCheck passes

## Homebrew Tap
Updated `homebrew-tap/mac-cleans.rb` to v5.1.1 - already pushed directly to main.

## Summary by Sourcery

Fix Time Machine local snapshot handling when no snapshots are present and document the change for the 5.1.1 release.

Bug Fixes:
- Prevent integer expression errors when counting Time Machine local snapshots on systems with no existing snapshots.

Documentation:
- Add CHANGELOG entry for version 5.1.1 describing the Time Machine snapshot count bug fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an error that occurred when no local Time Machine snapshots were present, preventing misleading snapshot-count results.
  * Improved snapshot-count handling so operations now proceed reliably and report an accurate integer count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->