### PR TITLE
fix: handle find 'Operation not permitted' error (v5.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to MacCleans.sh are documented in this file.
 
+## [5.1.2] - 2026-03-29
+
+### Bug Fixes
+
+- **iOS backup permission error** - Fixed script exiting silently when `find` returns "Operation not permitted" on the iOS backup directory by adding `|| IOS_BACKUP_COUNT=0` fallback and value normalization to prevent `set -e` from triggering on expected permission errors
+
 ## [5.1.1] - 2026-03-28
 
 ### Bug Fixes

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -3,7 +3,7 @@
 # Enable strict error handling
 set -euo pipefail
 
-VERSION="5.1"
+VERSION="5.1.2"
 
 ###############################################################################
 # Mac-Clean: macOS Disk Cleanup Utility
@@ -2583,7 +2583,8 @@ if [ "$SKIP_IOS_BACKUPS" = false ]; then
 
     IOS_BACKUP_DIR="$USER_HOME/Library/Application Support/MobileSync/Backup"
     if [ -d "$IOS_BACKUP_DIR" ]; then
-        IOS_BACKUP_COUNT=$(find "$IOS_BACKUP_DIR" -maxdepth 1 -type d -not -path "$IOS_BACKUP_DIR" 2>/dev/null | wc -l | tr -d ' ')
+        IOS_BACKUP_COUNT=$(find "$IOS_BACKUP_DIR" -maxdepth 1 -type d -not -path "$IOS_BACKUP_DIR" 2>/dev/null | wc -l | tr -d ' ') || IOS_BACKUP_COUNT=0
+        IOS_BACKUP_COUNT=${IOS_BACKUP_COUNT:-0}
 
         if [ "$IOS_BACKUP_COUNT" -gt 0 ]; then
             IOS_BACKUP_SIZE=$(du -sh "$IOS_BACKUP_DIR" 2>/dev/null | awk '{print $1}' || echo "0B")
@@ -3059,7 +3060,8 @@ if [ "$DRY_RUN" = true ]; then
     if [ "$SKIP_IOS_BACKUPS" = false ]; then
         IOS_BACKUP_DIR="$USER_HOME/Library/Application Support/MobileSync/Backup"
         if [ -d "$IOS_BACKUP_DIR" ]; then
-            IOS_BACKUP_COUNT=$(find "$IOS_BACKUP_DIR" -maxdepth 1 -type d -not -path "$IOS_BACKUP_DIR" 2>/dev/null | wc -l | tr -d ' ')
+            IOS_BACKUP_COUNT=$(find "$IOS_BACKUP_DIR" -maxdepth 1 -type d -not -path "$IOS_BACKUP_DIR" 2>/dev/null | wc -l | tr -d ' ') || IOS_BACKUP_COUNT=0
+        IOS_BACKUP_COUNT=${IOS_BACKUP_COUNT:-0}
             if [ "$IOS_BACKUP_COUNT" -gt 0 ]; then
                 log_always "${RED}${BOLD}⚠️  CRITICAL: iOS Device Backups Will Be Deleted!${NC}"
                 log_always "${YELLOW}   Found $IOS_BACKUP_COUNT backup(s) that will require 'DELETE' confirmation${NC}"


### PR DESCRIPTION
## Summary
- Fix script silently exiting after category 21 (iOS Device Backups) when `find` encounters "Operation not permitted" on MobileSync/Backup directory
- Add `|| true` to find command to prevent `set -e` from triggering on expected permission errors
- Version: 5.1.1 → 5.1.2

## Bug Details
When running `mac-cleans --dry-run`, the script would silently exit after "21. iOS Device Backups" with no error message and no summary. This was caused by:
1. `set -euo pipefail` at the top of the script
2. `find` returning exit code 1 when "Operation not permitted"
3. `pipefail` propagating the error through the pipeline
4. `set -e` immediately exiting the script

## Testing
- [x] `bash -n` syntax check passes
- [x] ShellCheck passes
- [x] Tested on affected machine (categories 22-26 now visible)

## Homebrew
Will update `homebrew-tap/mac-cleans.rb` to v5.1.2 after merge.

## Summary by Sourcery

Resolve premature script exit when scanning iOS backups and bump script version to 5.1.2.

Bug Fixes:
- Prevent the iOS backup scan from terminating the entire script when `find` encounters expected permission errors.

Documentation:
- Document the 5.1.2 bug fix for iOS backup permission handling in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the tool could abort unexpectedly when encountering permission-restricted iOS backup directories; now it reliably continues and reports counts.
* **Chores**
  * Released version 5.1.2 with the above reliability improvements and safer backup counting in summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->