### PR TITLE
fix: address security review P0s (v5.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to MacCleans.sh are documented in this file.
 
+## [5.2.0] - 2026-06-01
+
+### Security Fixes
+
+- **iCloud backup detection was misfiring as root** - `check_icloud_backup_enabled` ran `defaults read MobileMeAccounts` as root, which always reads the root user's (empty) Apple ID plist, causing the iOS-backup safety gate to fail-close for the wrong reason. Now drops privileges via `sudo -u $ACTUAL_USER` when running as root. Also switched the Backup.log lookup from `$HOME` to the validated `$USER_HOME` so a `sudo` invocation that resets env no longer points at `/var/root`. Users with iCloud backup enabled will now see the safety gate behave as intended (and may need to set `--force-ios-backups` to actually clean backups, as the docs describe).
+- **iCloud Drive symlink-swap TOCTOU** - The iCloud Drive cleanup now pins `~/Library/CloudStorage` to its real (symlink-resolved) location before the per-folder glob, and re-checks `[ -L ]` on each folder immediately before deletion. Both `find` calls now use `find -P` explicitly. Closes the residual parent-swap and child-swap windows from the original `d73bef6` mitigation.
+
+### Bug Fixes
+
+- **Installer hash pinned to old release** - `installer.sh` shipped a hardcoded `EXPECTED_HASH` that no longer matched the current `clean-mac-space.sh` SHA-256, so the `curl | bash` install path documented in README and 4 doc files was failing on hash mismatch. Hash regenerated and re-pinned.
+- **Doc: iCloud Drive path** - `docs/all-categories.md` listed the iCloud Drive path as `~/Library/Mobile Documents`; the actual code scans `~/Library/CloudStorage/iCloud Drive*`.
+- **Doc: Claude cache path** - `docs/all-categories.md` listed the Claude cache path as `~/Library/Caches/Claude`; the script only clears the auto-update cache at `~/Library/Caches/com.anthropic.claudefordesktop.ShipIt`.
+
 ## [5.1.7] - 2026-04-12
 
 ### Security Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to MacCleans.sh are documented in this file.
 ### Security Fixes
 
 - **iCloud backup detection was misfiring as root** - `check_icloud_backup_enabled` ran `defaults read MobileMeAccounts` as root, which always reads the root user's (empty) Apple ID plist, causing the iOS-backup safety gate to fail-close for the wrong reason. Now drops privileges via `sudo -u $ACTUAL_USER` when running as root. Also switched the Backup.log lookup from `$HOME` to the validated `$USER_HOME` so a `sudo` invocation that resets env no longer points at `/var/root`. Users with iCloud backup enabled will now see the safety gate behave as intended (and may need to set `--force-ios-backups` to actually clean backups, as the docs describe).
-- **iCloud Drive symlink-swap TOCTOU** - The iCloud Drive cleanup now pins `~/Library/CloudStorage` to its real (symlink-resolved) location before the per-folder glob, and re-checks `[ -L ]` on each folder immediately before deletion. Both `find` calls now use `find -P` explicitly. Closes the residual parent-swap and child-swap windows from the original `d73bef6` mitigation.
+- **iCloud Drive symlink-swap TOCTOU** - The iCloud Drive cleanup now fails closed if `~/Library/CloudStorage` itself is a symlink (defense-in-depth against a co-resident attacker redirecting the cleanup), and re-checks `[ -L ]` on each folder immediately before deletion. Both `find` calls now use `find -P` explicitly. Closes the parent-swap and child-swap windows from the original `d73bef6` mitigation. *Note: an earlier draft of this change resolved and followed the symlink; CodeRabbit review correctly flagged that as the wrong posture for a root-run script. Thanks, CodeRabbit.*
 
 ### Bug Fixes
 

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -4,7 +4,7 @@
 # Enable strict error handling
 set -euo pipefail
 
-VERSION="5.1.7"
+VERSION="5.2.0"
 
 ###############################################################################
 # Mac-Clean: macOS Disk Cleanup Utility

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -702,32 +702,45 @@ check_minimum_disk_space() {
 check_icloud_backup_enabled() {
     # Try to check iCloud backup status using defaults
     # Note: This is a best-effort check - we look for signs that iCloud backup is configured
-    
+
+    # When running as root, the MobileMeAccounts defaults domain is the root
+    # user's (root has no Apple ID), so a bare `defaults read` would always
+    # be empty and this function would fail-close for the WRONG reason.
+    # Drop privileges via sudo -u to read the invoking user's real plist.
+    local -a defaults_cmd
+    if [ "$(id -u)" = "0" ] && [ -n "${ACTUAL_USER:-}" ]; then
+        defaults_cmd=(sudo -u "$ACTUAL_USER" defaults)
+    else
+        defaults_cmd=(defaults)
+    fi
+
     # Check if iCloud account is signed in
-    if ! defaults read MobileMeAccounts Accounts 2>/dev/null | grep -q "AccountID"; then
+    if ! "${defaults_cmd[@]}" read MobileMeAccounts Accounts 2>/dev/null | grep -q "AccountID"; then
         # No iCloud account signed in, so iCloud backup is definitely not enabled
         return 1
     fi
-    
+
     # Check for com.apple.preferences.icloud.backup settings
     # If the key exists and is set to 1, backup is enabled
     local backup_enabled
-    backup_enabled=$(defaults read com.apple.preferences.icloud.backup Enabled 2>/dev/null || echo "0")
-    
+    backup_enabled=$("${defaults_cmd[@]}" read com.apple.preferences.icloud.backup Enabled 2>/dev/null || echo "0")
+
     if [ "$backup_enabled" = "1" ]; then
         return 0
     fi
-    
+
     # Also check if there's evidence of recent iCloud backups in the log
-    # This is a secondary check to be more permissive
-    if [ -f "$HOME/Library/Logs/MobileBackup/Backup.log" ]; then
+    # This is a secondary check to be more permissive.
+    # Use $USER_HOME (validated + symlink-resolved) instead of $HOME so a
+    # `sudo` invocation that resets env doesn't point us at /var/root.
+    if [ -f "$USER_HOME/Library/Logs/MobileBackup/Backup.log" ]; then
         local recent_backup
-        recent_backup=$(find "$HOME/Library/Logs/MobileBackup" -name "Backup.log" -mtime -30 2>/dev/null | wc -l)
-        if [ "$recent_backup" -gt 0 ]; then
+        recent_backup=$(find "$USER_HOME/Library/Logs/MobileBackup" -name "Backup.log" -mtime -30 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$recent_backup" -gt 0 ] 2>/dev/null; then
             return 0
         fi
     fi
-    
+
     return 1
 }
 
@@ -2448,6 +2461,23 @@ if [ "$SKIP_ICLOUD_DRIVE" = false ]; then
     log_plain "================================================"
 
     CLOUD_STORAGE_DIR="$USER_HOME/Library/CloudStorage"
+
+    # Pin CLOUD_STORAGE_DIR to its real (symlink-resolved) location to close
+    # the parent-symlink-swap TOCTOU window. If Library/CloudStorage itself is
+    # a symlink, the per-folder glob would otherwise resolve through it and
+    # list attacker-chosen paths under the symlink target. macOS BSD readlink
+    # does not have -f, so we resolve manually (matches the pattern at the
+    # USER_HOME resolution above).
+    if [ -L "$CLOUD_STORAGE_DIR" ] && command -v readlink >/dev/null 2>&1; then
+        cs_link_target=$(readlink "$CLOUD_STORAGE_DIR")
+        if [ -n "$cs_link_target" ]; then
+            if [[ "$cs_link_target" == /* ]]; then
+                CLOUD_STORAGE_DIR="$cs_link_target"
+            else
+                CLOUD_STORAGE_DIR="$(cd "$(dirname "$CLOUD_STORAGE_DIR")" && pwd)/$cs_link_target"
+            fi
+        fi
+    fi
     ICLOUD_DRIVE_BYTES=0
 
     # Check if CloudStorage directory exists
@@ -2509,11 +2539,20 @@ if [ "$SKIP_ICLOUD_DRIVE" = false ]; then
                                 log_warning "iCloud sync status changed for $folder during check - aborting deletion"
                                 continue
                             fi
-                            
-                            # Note: -type f/d excludes symlinks (safety feature), 
-                            # so du -sk accounting may slightly overstate freed space
-                            find "$folder" -type f -mindepth 1 -delete 2>/dev/null || true
-                            find "$folder" -type d -mindepth 1 -depth -empty -delete 2>/dev/null || true
+
+                            # Re-check the folder is not a symlink just before the
+                            # destructive step (closes the child-swap window that
+                            # opens between the [ -L ] test above and this find).
+                            if [ -L "$folder" ]; then
+                                log_warning "Folder became a symlink during check: $folder - aborting"
+                                continue
+                            fi
+
+                            # Note: -type f/d excludes symlinks (safety feature),
+                            # so du -sk accounting may slightly overstate freed space.
+                            # -P forces find to never follow symlinks explicitly.
+                            find -P "$folder" -type f -mindepth 1 -delete 2>/dev/null || true
+                            find -P "$folder" -type d -mindepth 1 -depth -empty -delete 2>/dev/null || true
                         done
                         log_success "iCloud Drive files removed"
                         log "${RED}WARNING: Files pending upload are PERMANENTLY LOST!${NC}"

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -4,7 +4,7 @@
 # Enable strict error handling
 set -euo pipefail
 
-VERSION="5.2.0"
+VERSION="5.1.7"
 
 ###############################################################################
 # Mac-Clean: macOS Disk Cleanup Utility
@@ -702,45 +702,32 @@ check_minimum_disk_space() {
 check_icloud_backup_enabled() {
     # Try to check iCloud backup status using defaults
     # Note: This is a best-effort check - we look for signs that iCloud backup is configured
-
-    # When running as root, the MobileMeAccounts defaults domain is the root
-    # user's (root has no Apple ID), so a bare `defaults read` would always
-    # be empty and this function would fail-close for the WRONG reason.
-    # Drop privileges via sudo -u to read the invoking user's real plist.
-    local -a defaults_cmd
-    if [ "$(id -u)" = "0" ] && [ -n "${ACTUAL_USER:-}" ]; then
-        defaults_cmd=(sudo -u "$ACTUAL_USER" defaults)
-    else
-        defaults_cmd=(defaults)
-    fi
-
+    
     # Check if iCloud account is signed in
-    if ! "${defaults_cmd[@]}" read MobileMeAccounts Accounts 2>/dev/null | grep -q "AccountID"; then
+    if ! defaults read MobileMeAccounts Accounts 2>/dev/null | grep -q "AccountID"; then
         # No iCloud account signed in, so iCloud backup is definitely not enabled
         return 1
     fi
-
+    
     # Check for com.apple.preferences.icloud.backup settings
     # If the key exists and is set to 1, backup is enabled
     local backup_enabled
-    backup_enabled=$("${defaults_cmd[@]}" read com.apple.preferences.icloud.backup Enabled 2>/dev/null || echo "0")
-
+    backup_enabled=$(defaults read com.apple.preferences.icloud.backup Enabled 2>/dev/null || echo "0")
+    
     if [ "$backup_enabled" = "1" ]; then
         return 0
     fi
-
+    
     # Also check if there's evidence of recent iCloud backups in the log
-    # This is a secondary check to be more permissive.
-    # Use $USER_HOME (validated + symlink-resolved) instead of $HOME so a
-    # `sudo` invocation that resets env doesn't point us at /var/root.
-    if [ -f "$USER_HOME/Library/Logs/MobileBackup/Backup.log" ]; then
+    # This is a secondary check to be more permissive
+    if [ -f "$HOME/Library/Logs/MobileBackup/Backup.log" ]; then
         local recent_backup
-        recent_backup=$(find "$USER_HOME/Library/Logs/MobileBackup" -name "Backup.log" -mtime -30 2>/dev/null | wc -l | tr -d ' ')
-        if [ "$recent_backup" -gt 0 ] 2>/dev/null; then
+        recent_backup=$(find "$HOME/Library/Logs/MobileBackup" -name "Backup.log" -mtime -30 2>/dev/null | wc -l)
+        if [ "$recent_backup" -gt 0 ]; then
             return 0
         fi
     fi
-
+    
     return 1
 }
 
@@ -2462,22 +2449,20 @@ if [ "$SKIP_ICLOUD_DRIVE" = false ]; then
 
     CLOUD_STORAGE_DIR="$USER_HOME/Library/CloudStorage"
 
-    # Pin CLOUD_STORAGE_DIR to its real (symlink-resolved) location to close
-    # the parent-symlink-swap TOCTOU window. If Library/CloudStorage itself is
-    # a symlink, the per-folder glob would otherwise resolve through it and
-    # list attacker-chosen paths under the symlink target. macOS BSD readlink
-    # does not have -f, so we resolve manually (matches the pattern at the
-    # USER_HOME resolution above).
-    if [ -L "$CLOUD_STORAGE_DIR" ] && command -v readlink >/dev/null 2>&1; then
-        cs_link_target=$(readlink "$CLOUD_STORAGE_DIR")
-        if [ -n "$cs_link_target" ]; then
-            if [[ "$cs_link_target" == /* ]]; then
-                CLOUD_STORAGE_DIR="$cs_link_target"
-            else
-                CLOUD_STORAGE_DIR="$(cd "$(dirname "$CLOUD_STORAGE_DIR")" && pwd)/$cs_link_target"
-            fi
-        fi
-    fi
+    # Defensive: if Library/CloudStorage itself is a symlink, fail closed.
+    # A co-resident attacker with write access to $USER_HOME could redirect
+    # this whole cleanup to an arbitrary directory by symlinking CloudStorage;
+    # the per-folder [ -L ] checks below catch the CHILD-swap case, but they
+    # cannot prevent the root redirect. We refuse to walk the symlink at all
+    # and surface a clear error so the user can investigate. (Earlier draft
+    # resolved and followed the symlink; that was wrong — CodeRabbit caught
+    # it during PR review. Thanks, CodeRabbit.)
+    if [ -L "$CLOUD_STORAGE_DIR" ]; then
+        log_error "Refusing iCloud Drive cleanup: $CLOUD_STORAGE_DIR is a symlink (symlink-swap defense)."
+        log_error "Inspect the symlink target, then re-run, or use --skip-icloud-drive to silence."
+        SKIPPED_CATEGORIES+=("iCloud Drive Offline Files (CloudStorage is a symlink)")
+        log_plain ""
+    else
     ICLOUD_DRIVE_BYTES=0
 
     # Check if CloudStorage directory exists
@@ -2539,20 +2524,11 @@ if [ "$SKIP_ICLOUD_DRIVE" = false ]; then
                                 log_warning "iCloud sync status changed for $folder during check - aborting deletion"
                                 continue
                             fi
-
-                            # Re-check the folder is not a symlink just before the
-                            # destructive step (closes the child-swap window that
-                            # opens between the [ -L ] test above and this find).
-                            if [ -L "$folder" ]; then
-                                log_warning "Folder became a symlink during check: $folder - aborting"
-                                continue
-                            fi
-
-                            # Note: -type f/d excludes symlinks (safety feature),
-                            # so du -sk accounting may slightly overstate freed space.
-                            # -P forces find to never follow symlinks explicitly.
-                            find -P "$folder" -type f -mindepth 1 -delete 2>/dev/null || true
-                            find -P "$folder" -type d -mindepth 1 -depth -empty -delete 2>/dev/null || true
+                            
+                            # Note: -type f/d excludes symlinks (safety feature), 
+                            # so du -sk accounting may slightly overstate freed space
+                            find "$folder" -type f -mindepth 1 -delete 2>/dev/null || true
+                            find "$folder" -type d -mindepth 1 -depth -empty -delete 2>/dev/null || true
                         done
                         log_success "iCloud Drive files removed"
                         log "${RED}WARNING: Files pending upload are PERMANENTLY LOST!${NC}"
@@ -2574,6 +2550,7 @@ if [ "$SKIP_ICLOUD_DRIVE" = false ]; then
         log "CloudStorage directory not found (iCloud Drive not configured)"
     fi
     log_plain ""
+    fi  # close the [ -L "$CLOUD_STORAGE_DIR" ] fail-closed check above
 else
     SKIPPED_CATEGORIES+=("iCloud Drive Offline Files")
 fi

--- a/docs/all-categories.md
+++ b/docs/all-categories.md
@@ -254,7 +254,7 @@ sudo Mac-Clean --yes --skip-spotify
 
 ### Claude
 
-**Path:** `~/Library/Caches/Claude`
+**Path:** `~/Library/Caches/com.anthropic.claudefordesktop.ShipIt`
 
 **Typical Size:** 100MB-1GB
 
@@ -336,7 +336,7 @@ sudo Mac-Clean --yes --skip-diagnostics
 
 ### iCloud Drive
 
-**Path:** `~/Library/Mobile Documents` (iCloud offline files)
+**Path:** `~/Library/CloudStorage/iCloud Drive*` (iCloud Drive folders under CloudStorage)
 
 **Typical Size:** Variable
 

--- a/docs/all-categories.md
+++ b/docs/all-categories.md
@@ -344,7 +344,7 @@ sudo Mac-Clean --yes --skip-diagnostics
 
 **Risk:** High - these are your actual files
 
-**Warning:** Only deletes files that are fully synced and available online. iCloud Drive remains intact.
+**Warning:** Best-effort sync check before deletion (looks for `.icloud` placeholders, `Conflict*` files, and recent mtimes). Local-only or in-progress uploads can still be lost. iCloud Drive content on the server is unaffected for files that were fully synced at deletion time. Will refuse to run if `~/Library/CloudStorage` itself is a symlink.
 
 **When to skip:** If you work offline frequently
 

--- a/installer.sh
+++ b/installer.sh
@@ -12,7 +12,7 @@ INSTALL_DIR="/usr/local/bin"
 SCRIPT_NAME="Mac-Clean"
 GITHUB_RAW_URL="https://raw.githubusercontent.com/Carme99/MacCleans.sh/main/clean-mac-space.sh"
 INSTALL_PATH="${INSTALL_DIR}/${SCRIPT_NAME}"
-EXPECTED_HASH="b105da75fffe80f467653dac8ba1f9a0b441affb1eadc492fbecc7181191b684"
+EXPECTED_HASH="9054379cd1ac84acfb4db8b3f5669b2ad9c1eca8a398ae5ecc0460356d86dc9f"
 
 # Colors
 RED='\033[0;31m'


### PR DESCRIPTION
## Summary

Closes all 5 P0 issues from the security review at `.mavis/plans/deliverables/REVIEW.md`. Two commits:

1. **`fix: address security review P0s`** (`3b90761`) — security + doc patches
2. **`chore: bump version to v5.2.0`** (`d11edf2`) — version + changelog

## What changed

### Security fixes (`clean-mac-space.sh`)

- **`check_icloud_backup_enabled` now reads the *user's* MobileMeAccounts plist** when running as root (was reading the root user's empty plist → safety gate was fail-closing for the wrong reason). Uses `sudo -u "$ACTUAL_USER" defaults` in a bash array to preserve proper argument separation. Also switched the Backup.log lookup from `$HOME` to the validated `$USER_HOME` so `sudo` env-reset no longer points at `/var/root`.

- **iCloud Drive cleanup pins `CLOUD_STORAGE_DIR` before the glob** to close the parent-swap TOCTOU window. Uses the same portable readlink pattern as the `USER_HOME` resolution (no `readlink -f` — that's GNU-only, macOS BSD readlink doesn't have it). Inside the per-folder loop: added a second `[ -L ]` check immediately before deletion, and both `find` calls now use `find -P` explicitly to never follow symlinks.

### Bug fixes

- **`installer.sh:15` `EXPECTED_HASH` regenerated** to match current `clean-mac-space.sh` SHA-256. The `curl | bash` install path documented everywhere was failing on hash mismatch.

### Doc fixes (`docs/all-categories.md`)

- iCloud Drive path: `~/Library/Mobile Documents` → `~/Library/CloudStorage/iCloud Drive*`
- Claude cache path: `~/Library/Caches/Claude` → `~/Library/Caches/com.anthropic.claudefordesktop.ShipIt`

## Why v5.2.0 (minor, not patch)

The iCloud backup check fix is a **user-visible behavior change**: users with iCloud backup enabled will now see the safety gate behave as documented (and may need to set `--force-ios-backups` to actually clean backups, as the docs already describe). Per semver, behavior changes that don't break existing usage are minor bumps.

## Testing

- `bash -n clean-mac-space.sh installer.sh` — both pass
- `shellcheck -f gcc -S warning clean-mac-space.sh installer.sh` — zero findings at default + warning severity
- Verified the new `EXPECTED_HASH` matches the actual SHA-256 of the patched `clean-mac-space.sh`
- `git diff` reviewed — 60 lines net change, no incidental edits

## PR template checklist

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Documentation update
- [x] I have tested this locally (`bash -n` + `shellcheck` clean, hash verified)
- [x] I have added `--skip-*` flag for any new cleanup category — N/A, no new categories
- [x] My code follows the project's style guidelines

## Full review

The full prioritized review (P0/P1/P2 action list) is at `.mavis/plans/deliverables/REVIEW.md` in the working tree. The other P1 items (broken `docs/guides/` links, stale `developer-guide.md`, undocumented `--skip-system-tmp`/`--clean-system-tmp`, etc.) can be follow-up PRs.

## Summary by Sourcery

Address security review P0 findings and prepare the 5.2.0 release.

Bug Fixes:
- Update installer script hash to match the current clean-mac-space.sh release, restoring the documented curl | bash install path.

Enhancements:
- Bump script version and changelog to 5.2.0 with release notes for security and bug fixes.

Documentation:
- Correct documented paths for iCloud Drive storage and Claude cache to match the actual cleanup behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Fixes**
  * Enhanced iCloud backup detection when running as root with privilege management
  * Hardened iCloud Drive symlink handling against swap attacks

* **Bug Fixes**
  * Updated verification hash for installer integrity checks
  * Corrected Claude cache path detection

* **Documentation**
  * Fixed Claude cache and iCloud Drive cleanup path documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->