### PR TITLE
docs: replace broken ASCII art + bump version badge to 5.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
 # MacCleans
 
 ```
-██████╗ ███████╗███████╗██╗   ██╗███████╗
-██╔══██╗██╔════╝██╔════╝██║   ██║██╔════╝
-██║  ██║█████╗  █████╗  ██║   ██║███████╗
-██║  ██║██╔══╝  ██╔══╝  ╚██╗ ██╔╝╚════██║
-██████╔╝███████╗███████╗ ╚████╔╝  ███████║
-╚═════╝ ╚══════╝╚══════╝  ╚═══╝   ╚══════╝
+  __  __                   ____   _                              
+ |  \/  |   __ _    ___   / ___| | |   ___    __ _   _ __    ___ 
+ | |\/| |  / _` |  / __| | |     | |  / _ \  / _` | | '_ \  / __|
+ | |  | | | (_| | | (__  | |___  | | |  __/ | (_| | | | | | \__ \
+ |_|  |_|  \__,_|  \___|  \____| |_|  \___|  \__,_| |_| |_| |___/
 ```
 
 **Free 10-50GB on your Mac with one command.**
 
-[![Version](https://img.shields.io/badge/Version-5.3.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-5.4.0-blue.svg)](CHANGELOG.md)
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/Carme99/MacCleans.sh?utm_source=oss&utm_medium=github&utm_campaign=Carme99%2FMacCleans.sh&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![macOS](https://img.shields.io/badge/macOS-10.15+-blue.svg)](https://www.apple.com/macos/)


### PR DESCRIPTION
The README header was using figlet's `dos_rebel` font, which mixes Unicode box-drawing characters (╗╔╚╝) with ASCII letters. The result in any monospace rendering context is unreadable — the boxes overlap the letters and the wordmark falls apart. Especially bad on the GitHub project page.

## What's in here

- `README.md` — replace the broken DOS Rebel art with figlet's `Standard` font. Pure ASCII characters only (underscore, pipe, slash), 6 rows × 65 columns. Renders consistently in every monospace context.
- `README.md` — bump the version badge from 5.3.0 to 5.4.0 (stale since the v5.4.0 release at commit `003d5b3`).

Generated with `figlet -f standard -W 'MacCleans'`.

Before / after:

```
██████╗ ███████╗███████╗██╗   ██╗███████╗  →   __  __                   ____   _
██╔══██╗██╔════╝██╔════╝██║   ██║██╔════╝  → |  \/  |   __ _    ___   / ___| | |
██║  ██║█████╗  █████╗  ██║   ██║███████╗  → | |\/| |  / _` |  / __| | |     | |
██║  ██║██╔══╝  ██╔══╝  ╚██╗ ██╔╝╚════██║  → | |  | | | (_| | | (__  | |___  | |
██████╔╝███████╗███████╗ ╚████╔╝  ███████║  → |_|  |_|  \__,_|  \___|  \____| |_|
╚═════╝ ╚══════╝╚══════╝  ╚═══╝   ╚══════╝  →
```

## Summary by Sourcery

Update the README header branding and version badge to reflect the current release.

Documentation:
- Replace the README ASCII art header with a more readable, pure-ASCII figlet banner.
- Update the README version badge from 5.3.0 to 5.4.0 to match the latest release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated version reference from 5.3.0 to 5.4.0 in project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->