### PR TITLE
fix: v5.5 polish — --help bug, X-25 config validation, completion coverage

### DIFF
--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -243,6 +243,21 @@ load_config_file() {
                     FORCE_IOS_BACKUPS) FORCE_IOS_BACKUPS="$value" ;;
                     UPDATE) UPDATE="$value" ;;
                     VERBOSE) VERBOSE="$value" ;;
+                    PHOTOS_LIBRARY_NAME)
+                        # Apply the same path-traversal guard the CLI flag
+                        # uses (mirrors parse_arguments: --photos-library).
+                        # The handler that uses the value composes
+                        # "$USER_HOME/Pictures/${PHOTOS_LIBRARY_NAME}.photoslibrary",
+                        # so a value containing /, \, ~, .., or non-printable
+                        # characters would break out of Pictures/ entirely.
+                        PHOTOS_LIBRARY_NAME="$value"
+                        if [[ "$PHOTOS_LIBRARY_NAME" =~ [/~\\] ]] || \
+                           [[ "$PHOTOS_LIBRARY_NAME" == *".."* ]] || \
+                           [[ "$PHOTOS_LIBRARY_NAME" =~ [^[:print:]] ]]; then
+                            echo "ERROR: PHOTOS_LIBRARY_NAME in config file contains path-traversal or non-printable characters — refusing to use it" >&2
+                            exit 1
+                        fi
+                        ;;
                     *) echo "WARNING: Unknown config key '$key' - ignoring" >&2 ;;
                 esac
             done < "$config_file"
@@ -448,16 +463,27 @@ parse_arguments() {
                 shift 2
                 ;;
             --help|-h)
-                # Extract header comment block dynamically - find first non-comment line
-                line_num=0
+                # Extract the help block: the comment block delimited by
+                # lines of `###...###` markers in the script header.
+                # Print everything between the opening and closing
+                # marker (exclusive), stripping the leading `# `.
+                in_block=false
                 while IFS= read -r line; do
-                    line_num=$((line_num + 1))
-                    # Stop at first non-comment line
-                    if [[ ! "$line" =~ ^[[:space:]]*# ]]; then
-                        break
+                    # Skip the shebang
+                    [[ "$line" == "#!"* ]] && continue
+                    if [[ "$line" =~ ^[[:space:]]*#\#+[[:space:]]*$ ]]; then
+                        # A `###...###` marker line.
+                        if $in_block; then
+                            # Closing marker — done.
+                            break
+                        fi
+                        # Opening marker — start printing from the next line.
+                        in_block=true
+                        continue
                     fi
-                    # Print with # prefix stripped
-                    echo "${line#\# }"
+                    if $in_block; then
+                        echo "${line#\# }"
+                    fi
                 done < "$0"
                 exit 0
                 ;;

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -156,6 +156,18 @@ validate_numeric() {
     return 0
 }
 
+# Validate a Photos library name. The name is later composed into
+# "$USER_HOME/Pictures/${name}.photoslibrary", so any of /, \, ~, ..,
+# or non-printable characters would break out of the intended Pictures/
+# directory or smuggle a path in. Returns 0 on success, 1 on failure.
+validate_photos_library_name() {
+    local name="$1"
+    [[ "$name" =~ [/~\\] ]] && return 1
+    [[ "$name" == *".."* ]] && return 1
+    [[ "$name" =~ [^[:print:]] ]] && return 1
+    return 0
+}
+
 # Validate configuration values
 validate_config() {
     local errors=0
@@ -246,14 +258,9 @@ load_config_file() {
                     PHOTOS_LIBRARY_NAME)
                         # Apply the same path-traversal guard the CLI flag
                         # uses (mirrors parse_arguments: --photos-library).
-                        # The handler that uses the value composes
-                        # "$USER_HOME/Pictures/${PHOTOS_LIBRARY_NAME}.photoslibrary",
-                        # so a value containing /, \, ~, .., or non-printable
-                        # characters would break out of Pictures/ entirely.
+                        # See validate_photos_library_name() for the rule.
                         PHOTOS_LIBRARY_NAME="$value"
-                        if [[ "$PHOTOS_LIBRARY_NAME" =~ [/~\\] ]] || \
-                           [[ "$PHOTOS_LIBRARY_NAME" == *".."* ]] || \
-                           [[ "$PHOTOS_LIBRARY_NAME" =~ [^[:print:]] ]]; then
+                        if ! validate_photos_library_name "$PHOTOS_LIBRARY_NAME"; then
                             echo "ERROR: PHOTOS_LIBRARY_NAME in config file contains path-traversal or non-printable characters — refusing to use it" >&2
                             exit 1
                         fi
@@ -453,10 +460,10 @@ parse_arguments() {
                     exit 1
                 fi
                 PHOTOS_LIBRARY_NAME="$2"
-                # Validate: reject path traversal attempts and dangerous characters
-                if [[ "$PHOTOS_LIBRARY_NAME" =~ [/~\\] ]] || \
-                   [[ "$PHOTOS_LIBRARY_NAME" == *".."* ]] || \
-                   [[ "$PHOTOS_LIBRARY_NAME" =~ [^[:print:]] ]]; then
+                # Validate: reject path traversal attempts and dangerous
+                # characters. Shared with the config-file loader via
+                # validate_photos_library_name().
+                if ! validate_photos_library_name "$PHOTOS_LIBRARY_NAME"; then
                     echo "ERROR: --photos-library must be a plain library name, not a path" >&2
                     exit 1
                 fi
@@ -466,7 +473,12 @@ parse_arguments() {
                 # Extract the help block: the comment block delimited by
                 # lines of `###...###` markers in the script header.
                 # Print everything between the opening and closing
-                # marker (exclusive), stripping the leading `# `.
+                # marker (exclusive), stripping the leading `#` plus one
+                # optional whitespace char (space or tab). Handles:
+                #   `# foo`    -> `foo`
+                #   `#\tfoo`   -> `foo`
+                #   `#foo`     -> `foo`
+                #   `#`        -> ``
                 in_block=false
                 while IFS= read -r line; do
                     # Skip the shebang
@@ -482,7 +494,9 @@ parse_arguments() {
                         continue
                     fi
                     if $in_block; then
-                        echo "${line#\# }"
+                        local stripped="${line#\#}"   # drop leading #
+                        stripped="${stripped#[ $'\t']}"  # drop one optional space or tab
+                        echo "$stripped"
                     fi
                 done < "$0"
                 exit 0

--- a/completions/_mac-cleans
+++ b/completions/_mac-cleans
@@ -11,6 +11,13 @@ _mac_cleans() {
         '--json[JSON output]'
         '--version[Show version]'
         '--help[Show help]'
+        '--quiet[Minimal output (useful for cron)]'
+        '--no-color[Disable colored output]'
+        '--verbose[Enable verbose debug output]'
+        '--update[Run brew update before cleanup]'
+        '--threshold[Only run if disk usage is above N% (0-100, default: 0)]: :->threshold_value'
+        '--profile[Use preset profile]: :(conservative developer aggressive minimal)'
+        '--photos-library[Specify Photos library name or "all"]: :->photos_name'
     )
 
     categories=(

--- a/completions/mac-cleans.bash
+++ b/completions/mac-cleans.bash
@@ -8,6 +8,8 @@ _mac_cleans() {
 
     local -a options=(
         --dry-run --force --yes --interactive --json --version --help
+        --quiet --no-color --verbose --update
+        --threshold --profile --photos-library
         --skip-snapshots --skip-homebrew --skip-spotify --skip-claude
         --skip-xcode --skip-browsers --skip-npm --skip-pip --skip-trash
         --skip-dsstore --skip-docker --skip-simulator --skip-mail

--- a/completions/mac-cleans.fish
+++ b/completions/mac-cleans.fish
@@ -9,6 +9,13 @@ complete -c mac-cleans -s f -l force -d 'Skip all confirmations'
 complete -c mac-cleans -s y -l yes -d 'Skip confirmations (except Xcode)'
 complete -c mac-cleans -s i -l interactive -d 'Interactive mode'
 complete -c mac-cleans -s j -l json -d 'JSON output'
+complete -c mac-cleans -s q -l quiet -d 'Minimal output (useful for cron)'
+complete -c mac-cleans -l no-color -d 'Disable colored output'
+complete -c mac-cleans -s V -l verbose -d 'Enable verbose debug output'
+complete -c mac-cleans -s u -l update -d 'Run brew update before cleanup'
+complete -c mac-cleans -l threshold -d 'Only run if disk usage is above N%' -r
+complete -c mac-cleans -l profile -d 'Use preset profile' -r -a 'conservative developer aggressive minimal'
+complete -c mac-cleans -l photos-library -d 'Specify Photos library name or "all"' -r
 
 complete -c mac-cleans -l skip-snapshots -d 'Skip Time Machine snapshots'
 complete -c mac-cleans -l skip-homebrew -d 'Skip Homebrew cache'

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -101,7 +101,7 @@ sudo Mac-Clean --dry-run --json
 **Example output:**
 ```json
 {
-  "version": "5.3.0",
+  "version": "5.4.0",
   "timestamp": "2026-04-09T12:00:00Z",
   "dry_run": true,
   "results": {

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -40,7 +40,7 @@ There is intentionally **no `tests/` directory and no `npm test`** — MacCleans
 10. **Disk / size helpers** — `safe_du`, `size_to_bytes`, `bytes_to_human`, `check_disk_space`, `check_minimum_disk_space` (lines ~846-925)
 11. **Health checks** — `perform_health_checks` (line 1031)
 12. **Profile loader** — `load_profile` (line 1071)
-13. **Category cleanup sections** — 29 top-level procedural blocks, numbered #1 through #29 (the source of finding F-2 in the v5.2.0 review — there's no #23 because the blocks were hand-numbered and the gap was missed)
+13. **Category cleanup sections** — 29 top-level procedural blocks, numbered #1 through #29 continuously (the F-2 numbering gap that was noted in the v5.2.0 review was fixed in v5.4.0; the root-cause refactor into a `CATEGORY_REGISTRY` + `run_category` dispatcher is still F-5)
 14. **JSON output** (the trailing `# Deliver results as JSON` block)
 
 ## Adding a New Category
@@ -221,8 +221,8 @@ Found a bug? Open an issue with:
 
 These are open items from the v5.2.0 review that future contributors may want to tackle:
 
-- **F-2**: the numbered category sections jump from #22 to #24 (no #23). Source of this is that the numbering is hand-maintained in the section comment, the `log` call, and the interactive menu. Adding a new category makes it easy to mis-number again. A future refactor could introduce a `CATEGORY_REGISTRY` array and a `run_category` dispatcher (this is the v5.2.0 review's F-5).
-- **F-3**: in `--dry-run --json` mode, `disk_usage.after` is always `0` (line 3224). Should be `null` or computed.
+- **F-2**: ✅ fixed in v5.4.0 (PR #74). Sections now number 1-29 continuously.
+- **F-3**: ✅ fixed in v5.4.0 (PR #74). `disk_usage.after` is now `null` in dry-run JSON.
 - **F-4**: `check_minimum_disk_space` and `check_disk_space` are near-duplicate helpers. Consolidate.
 - **F-5**: 29 top-level procedural category blocks. Refactor into a registry.
 - **P2 #26**: `ludeeus/action-shellcheck@master` should be pinned to a SHA.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # MacCleans Documentation
 
 [![macOS](https://img.shields.io/badge/macOS-10.15+-blue.svg)](https://www.apple.com/macos/)
-[![Version](https://img.shields.io/badge/Version-5.3.0-blue.svg)](../CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-5.4.0-blue.svg)](../CHANGELOG.md)
 
 In-depth guides for understanding macOS maintenance and getting the most out of MacCleans.
 


### PR DESCRIPTION
Six small polish items, all from the v5.2.0 review backlog or bugs spotted during the v5.4.0 release. Single agent, ~1 hour, single coherent PR.

## What's in here

**Bugs (real, user-visible)**
- `clean-mac-space.sh --help` was printing 1 line instead of the full 65-line usage block. The header-extraction loop broke on the first blank line, so every `sudo Mac-Clean --help` user saw a useless one-liner. Rewrote the loop to find the opening and closing `###...###` markers in the script header and print everything between them. Skips the shebang. Tested: 65 lines, full block, correctly bounded.
- `PHOTOS_LIBRARY_NAME` in config files (X-25) is now validated against the same path-traversal guard the `--photos-library` CLI flag uses. Previously, `PHOTOS_LIBRARY_NAME=../etc/x` in `~/.maccleans.conf` would be loaded and then composed into `$USER_HOME/Pictures/../etc/x.photoslibrary`, escaping the intended Pictures/ directory. Rejects `/`, `\`, `~`, `..`, and non-printable characters. Config-load is fatal (matches the CLI flag's behavior).

**Polish / coverage**
- All three shell completions (`completions/mac-cleans.bash`, `_mac-cleans`, `mac-cleans.fish`) now include the 7 flags the v5.2.0 review's X-23 found missing from at least one shell: `--profile`, `--threshold`, `--update`, `--photos-library`, `--verbose`, `--quiet`, `--no-color`. Zsh gets value suggestions for `--profile` (conservative/developer/aggressive/minimal). Fish gets `-r` (requires arg) and `-a` (allowed values) annotations.
- Stale 5.3.0 version references in `docs/index.md` (badge) and `docs/command-reference.md` (JSON example) bumped to 5.4.0 — the v5.3.0 X-12 fix regressed when the v5.4.0 release didn't bump these in lockstep. Re-bumps both.
- `docs/developer-guide.md` F-2 entry updated (numbered section gap was fixed in v5.4.0). F-3 entry updated (`disk_usage.after=null` in dry-run fixed). F-4 and F-5 still open.

## Not in this batch

- **F-4** (consolidate `check_minimum_disk_space` + `check_disk_space`) — deferred, "not urgent"
- **F-5** (category registry refactor) — deferred, needs its own focused PR
- **X-27** (suppress "Running as user" / "Home directory" in `--quiet`) — already fixed in v5.3.0; `log()` checks `QUIET` directly. Verified by code inspection.
- **CLAUDE.md version bump** — file is gitignored (per the v5.4.0 `.gitignore` we added), per-developer, not source-controlled. The public version is in the README badge (already correct).

## Verification

- `bash -n`: pass
- `shellcheck -S warning`: pass on all changed files
- `--help`: 65 lines, full block, correctly bounded
- X-25 regex: tested with 7 positive + negative cases (all pass)
- All 7 missing completion flags: present in all 3 shells

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Polish MacCleans v5.x by fixing help output and config validation, updating shell completions, and syncing documentation with recent releases.

Bug Fixes:
- Ensure the --help flag prints the full header help block instead of a truncated one by correctly detecting the delimited comment region.
- Validate PHOTOS_LIBRARY_NAME values loaded from config files with the same path-traversal guard as the --photos-library CLI flag, rejecting unsafe names.

Enhancements:
- Expand Bash, Zsh, and Fish shell completions to cover all major flags, including profile, threshold, update, photos-library, verbose, quiet, and no-color, with value suggestions where supported.

Documentation:
- Update user-facing documentation to reference version 5.4.0 in badges and examples and mark F-2/F-3 review items as fixed in v5.4.0 within the developer guide.