### PR TITLE
fix: show row numbers in interactive menu + true iOS Sim success state

### DIFF
--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -1303,7 +1303,7 @@ interactive_selection() {
                 cursor_mark="${CYAN}>${NC} "
             fi
 
-            printf "%b%b %s\n" "$cursor_mark" "$status" "$display"
+            printf "%b%b %2d. %s\n" "$cursor_mark" "$status" "$((i+1))" "$display"
         done
 
         log_plain ""
@@ -2119,12 +2119,15 @@ if run_category "13|iOS Simulator Data|SKIP_SIMULATOR"; then
                 log "Cleaning unavailable iOS Simulators..."
                 if command -v xcrun &> /dev/null; then
                     SIM_BEFORE=$(du -sk "$SIMULATOR_DIR" 2>/dev/null | awk '{print $1}' || echo "0")
-                    xcrun simctl delete unavailable 2>/dev/null || log_warning "Could not delete unavailable simulators"
-                    SIM_AFTER=$(du -sk "$SIMULATOR_DIR" 2>/dev/null | awk '{print $1}' || echo "0")
-                    SIM_FREED=$(( (SIM_BEFORE - SIM_AFTER) * 1024 ))
-                    if [ "$SIM_FREED" -lt 0 ]; then SIM_FREED=0; fi
-                    TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + SIM_FREED))
-                    log_success "Unavailable iOS Simulators removed"
+                    if xcrun simctl delete unavailable 2>/dev/null; then
+                        SIM_AFTER=$(du -sk "$SIMULATOR_DIR" 2>/dev/null | awk '{print $1}' || echo "0")
+                        SIM_FREED=$(( (SIM_BEFORE - SIM_AFTER) * 1024 ))
+                        if [ "$SIM_FREED" -lt 0 ]; then SIM_FREED=0; fi
+                        TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + SIM_FREED))
+                        log_success "Unavailable iOS Simulators removed"
+                    else
+                        log_warning "Could not delete unavailable simulators"
+                    fi
                 else
                     log_warning "xcrun command not found, skipping"
                 fi


### PR DESCRIPTION
Two small bugs caught by actually running v5.5.0 on the user's machine (96.91G freed, 27G over estimate). Both are pure correctness / UX fixes — no refactor, no new features.

## Bug 1: interactive menu — rows not numbered despite the tip promising they are

**Before:**
```
Use ↑↓ arrow keys to navigate, Space/Enter to toggle
Press a=all, n=none, d=done, q=cancel

[✓] Time Machine Local Snapshots
[✓] Homebrew Cache
> [✓] System Temporary Files
...

Tip: Numbers 1-27 also work for quick toggle
```

The shortcut itself worked (the keypress handler maps digits to the row index) but the user had no way to know which digit maps to which row. Now each row shows ` %2d. ` before the display name:

```
[✓]  1. Time Machine Local Snapshots
[✓]  2. Homebrew Cache
> [✓]  5. System Temporary Files   <- the cursor is on row 5, so press 5
...

Tip: Numbers 1-27 also work for quick toggle
```

The `2` in `%2d` is the width so single-digit rows right-align under double-digit ones (row `5` and row `27` both column-aligned). `1-indexed` so the visible number matches what the user types.

## Bug 2: iOS Simulators — false-positive success on real failure

**Before (from the user's actual run):**
```
 Cleaning unavailable iOS Simulators...
⚠ Could not delete unavailable simulators
✓ Unavailable iOS Simulators removed
```

Direct contradiction: `xcrun simctl delete unavailable` failed (the ⚠ warning) but the script then logged a ✓ success. The old code was:
```bash
xcrun simctl delete unavailable 2>/dev/null || log_warning "..."
SIM_AFTER=...
SIM_FREED=...
TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + SIM_FREED))   # adds 0 since SIM_AFTER == SIM_BEFORE
log_success "Unavailable iOS Simulators removed"   # but says it worked!
```

Restructured to a proper `if/else`:
```bash
if xcrun simctl delete unavailable 2>/dev/null; then
    SIM_AFTER=...
    SIM_FREED=...
    TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + SIM_FREED))
    log_success "Unavailable iOS Simulators removed"
else
    log_warning "Could not delete unavailable simulators"
fi
```

A real failure now only emits the warning, the freed-bytes total stays accurate, and the summary table can't say a category succeeded when it didn't.

## Verification

- `bash -n clean-mac-space.sh` — clean
- `shellcheck -S warning clean-mac-space.sh` — clean
- Both bugs verified to be reachable from the existing `tests/run-tests.sh` (helpers-only coverage, doesn't exercise the run paths)

## Diff

`1 file changed, 10 insertions(+), 7 deletions(-)` — `clean-mac-space.sh` only.

## Summary by Sourcery

Fix interactive menu numbering and correct iOS simulator cleanup status handling.

Bug Fixes:
- Display 1-indexed row numbers in the interactive selection menu so numeric shortcuts map clearly to each item.
- Only report successful removal and byte savings for unavailable iOS simulators when `xcrun simctl delete unavailable` actually succeeds.