### PR TITLE
docs: PR template + release process checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,7 +28,8 @@ Pick the conventional-commit type that matches (this drives the version bump):
 ## Release follow-up (maintainer)
 
 > This section is a reminder for the maintainer — not a blocker for merging.
+> The `scripts/release.sh` step runs **after this PR is merged, on a clean `main` checkout, before opening the next PR**. It is never run from a feature branch.
 
-- [ ] This PR changes user-visible behavior → schedule a release (run `scripts/release.sh X.Y.Z`) **before opening the next PR**
+- [ ] This PR changes user-visible behavior → schedule a release (run `bash scripts/release.sh X.Y.Z` on `main`) **after merge, before opening the next PR**
 - [ ] This PR is `refactor:` / `docs:` / `chore:` etc. → no release needed
 - [ ] I have **not** already run `scripts/release.sh` for this change (the release commit goes on a separate, clean PR)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,34 @@
-## Summary
+## What kind of change is this?
 
-Brief description of the changes.
+Pick the conventional-commit type that matches (this drives the version bump):
 
-## Changes Made
+- [ ] `feat:` — new feature (→ minor version, e.g. `5.5.2` → `5.6.0`)
+- [ ] `fix:` — bug fix (→ patch version, e.g. `5.5.2` → `5.5.3`)
+- [ ] `refactor:` — code change with no behavior change (→ no version bump)
+- [ ] `perf:` — performance improvement with no behavior change (→ no version bump)
+- [ ] `docs:` — documentation only (→ no version bump)
+- [ ] `test:` — adding or fixing tests (→ no version bump)
+- [ ] `chore:` / `build:` / `ci:` — tooling, deps, CI config (→ no version bump)
 
-- Change 1
-- Change 2
+> Not sure which one? See [CONTRIBUTING.md § Commit Messages](../CONTRIBUTING.md#commit-messages) for the full table.
 
-## Type of Change
+## Description
 
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Documentation update
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+<!-- One or two sentences on WHAT and WHY. Link any related issue with `Closes #N` or `Fixes #N`. -->
 
-## Testing
+## Self-review checklist
 
-- [ ] Tested with `--dry-run` flag
-- [ ] Tested on macOS (version: ___)
-- [ ] ShellCheck passes (`shellcheck clean-mac-space.sh`)
-- [ ] No new warnings introduced
+- [ ] `bash tests/run-tests.sh` passes locally
+- [ ] `shellcheck -S warning clean-mac-space.sh` is clean (or new findings explained in PR)
+- [ ] `bash -n clean-mac-space.sh` passes (no syntax errors)
+- [ ] If user-visible: I added a `## [Unreleased]` entry to `CHANGELOG.md` describing the change
+- [ ] If this changes CLI behavior, JSON shape, or skip flags: I updated `docs/reference/commands.md`
+- [ ] No new `*.bak` / `*.swp` / editor backup files in the diff
 
-## Checklist
+## Release follow-up (maintainer)
 
-- [ ] My code follows the existing code style
-- [ ] I have updated the README if needed
-- [ ] I have updated the CHANGELOG if needed
-- [ ] I have added `--skip-*` flag for any new cleanup category
+> This section is a reminder for the maintainer — not a blocker for merging.
+
+- [ ] This PR changes user-visible behavior → schedule a release (run `scripts/release.sh X.Y.Z`) **before opening the next PR**
+- [ ] This PR is `refactor:` / `docs:` / `chore:` etc. → no release needed
+- [ ] I have **not** already run `scripts/release.sh` for this change (the release commit goes on a separate, clean PR)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -585,7 +585,9 @@ refactor(logging): improve error message formatting
 
 ## Release Process
 
-For maintainers releasing new versions:
+For maintainers releasing new versions.
+
+> **Full step-by-step lives in [docs/contributing/release-process.md](docs/contributing/release-process.md)** — the canonical checklist with the "release before next PR" rule, the four version files, and a worked example. This section is the short version.
 
 ### Version Numbering
 

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -1,0 +1,97 @@
+# Release Process
+
+This project uses **manual releases** triggered by a version tag push. `scripts/release.sh` handles the version-bumping ceremony; `.github/workflows/release.yml` handles the homebrew-tap + GitHub release updates on the push.
+
+## The golden rule
+
+> **Every PR that ships user-visible behavior is followed by a release before the next PR is opened.**
+
+This isn't enforced by automation (yet) — it lives in the PR template's "Release follow-up" section as a reminder. If a PR is `refactor:`, `docs:`, `chore:`, or similar, no release is needed.
+
+## The four version files
+
+A version bump touches exactly four files, all in the same commit:
+
+| File | What changes |
+|---|---|
+| `clean-mac-space.sh` | `VERSION="X.Y.Z"` (line 7) |
+| `installer.sh` | `EXPECTED_HASH="<sha256 of clean-mac-space.sh>"` — **regenerated** by `scripts/release.sh` |
+| `CHANGELOG.md` | Move the `[Unreleased]` entry into a new `## [X.Y.Z] - YYYY-MM-DD` section |
+| `README.md` (and `docs/README.md` if it exists) | The version badge |
+
+`scripts/release.sh` handles the first two automatically. The other two are manual.
+
+## The release checklist
+
+1. **All PRs for this release are merged on `main`**, with their `[Unreleased]` entries in `CHANGELOG.md`.
+2. **Worktree's clean and on `main`**:
+   ```bash
+   git checkout main
+   git pull --rebase
+   git status   # should be clean
+   ```
+3. **Run the release helper** from a `main` checkout (the script refuses to run on any other branch):
+   ```bash
+   bash scripts/release.sh 5.5.3
+   ```
+   What this does:
+   - Bumps `VERSION=` in `clean-mac-space.sh` to `5.5.3`
+   - Regenerates `EXPECTED_HASH` in `installer.sh` from the new script content (this is the part v5.2.0 forgot to do — bundling it into the same command prevents that drift)
+   - Runs `bash -n` and `shellcheck -S warning` to catch syntax regressions
+   - **Stages** both files but does **not** commit
+4. **Edit `CHANGELOG.md` manually**: rename the `[Unreleased]` section to `## [5.5.3] - YYYY-MM-DD` and add a fresh empty `## [Unreleased]` above it for the next cycle.
+5. **Edit the version badge** in `README.md` (and `docs/README.md` if it has one). One-line edit each.
+6. **Commit the release prep as a single chore commit**:
+   ```bash
+   git commit -m "chore: bump version to v5.5.3"
+   ```
+7. **Tag and push**:
+   ```bash
+   git tag v5.5.3
+   git push origin v5.5.3
+   ```
+   The tag push is what fires `.github/workflows/release.yml`.
+8. **Watch the [Actions tab](https://github.com/Carme99/MacCleans.sh/actions)** for the `Release` workflow to finish (~30 seconds). On success, the homebrew tap formula (`carme99/homebrew-tap/mac-cleans.rb`) is updated and a GitHub release is created.
+
+If the workflow fails, fix the underlying issue and either delete the tag locally + on origin and re-push, or use the **Run workflow** button on the Actions tab to re-run it manually.
+
+## Version numbering
+
+We follow [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** (`X.0.0`) — breaking change to a user-facing flag, JSON shape, or config-file format
+- **MINOR** (`x.X.0`) — new feature, new category, new flag (backward compatible)
+- **PATCH** (`x.x.X`) — bug fix, doc fix that ships in a release, or a grouping of small changes
+
+The PR template's "What kind of change is this?" section encodes this. A single `feat:` PR → minor. A `fix:` PR → patch. A `refactor:` PR → no version bump (fold it into the next `feat:` or `fix:` if you want a release to mention it).
+
+## Worked example (v5.5.2 → v5.5.3, hypothetical)
+
+Say PR #83 is a `fix:` for a Photos Library edge case:
+
+1. PR #83 is reviewed, merged, CI is green, `CHANGELOG.md` has a new `## [Unreleased]` entry
+2. (Optional, but recommended: open a "release prep" PR that just moves the `[Unreleased]` entry into a new `## [5.5.3] - 2026-06-06` section — keeps the release commit itself a clean diff against the v5.5.2 tag)
+3. Locally on `main`:
+   ```bash
+   bash scripts/release.sh 5.5.3
+   git add CHANGELOG.md README.md docs/README.md   # the files you edited in step 2
+   git commit -m "chore: bump version to v5.5.3"
+   git tag v5.5.3
+   git push origin v5.5.3
+   ```
+4. Watch Actions. 30 seconds later, `brew upgrade mac-cleans` picks up v5.5.3.
+
+## What this is **not**
+
+- **Not release-please.** We considered it — it would auto-generate the PR and tag — but at the current release volume (~3/month) the overhead doesn't pay off. Revisit if the project ever ships ≥1 release/week.
+- **Not a pre-commit hook.** CI shellcheck covers the same ground for a one-maintainer project, and a pre-commit hook would just be a slower version of the same check.
+- **Not auto-bumped on merge.** The release commit is a deliberate, separate action. Don't try to wire it up to "merge to main = release" — the manual gate is the whole point.
+
+## When something goes wrong
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `scripts/release.sh` refuses to run | Not on `main` | `git checkout main` |
+| Workflow fails with "couldn't compute sha256" | Tarball URL changed or GITHUB_REF_NAME is wrong | Check the [release workflow debugging notes](https://github.com/Carme99/MacCleans.sh/blob/main/.github/workflows/release.yml) |
+| Homebrew tap formula is wrong after release | Token (`HOMEBREW_TAP_TOKEN`) lost or rotated | See [CONTRIBUTING.md § One-time setup for the maintainer](../CONTRIBUTING.md#one-time-setup-for-the-maintainer) |
+| Want to undo a release | Tag was pushed but the tap/release is bad | Delete tag locally + on origin, fix the issue, re-tag. `git push origin :refs/tags/v5.5.3` to delete remotely. |

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -24,7 +24,7 @@ A version bump touches exactly four files, all in the same commit:
 ## The release checklist
 
 1. **All PRs for this release are merged on `main`**, with their `[Unreleased]` entries in `CHANGELOG.md`.
-2. **Worktree's clean and on `main`**:
+2. **Worktree is clean and on `main`**:
    ```bash
    git checkout main
    git pull --rebase
@@ -45,10 +45,10 @@ A version bump touches exactly four files, all in the same commit:
    ```bash
    git commit -m "chore: bump version to v5.5.3"
    ```
-7. **Tag and push**:
+7. **Tag and push** (push both the `main` refspec and the tag in one command — `git push origin <tag>` only uploads the tag ref, the underlying release commit and the new `main` tip need an explicit push too):
    ```bash
    git tag v5.5.3
-   git push origin v5.5.3
+   git push origin main v5.5.3
    ```
    The tag push is what fires `.github/workflows/release.yml`.
 8. **Watch the [Actions tab](https://github.com/Carme99/MacCleans.sh/actions)** for the `Release` workflow to finish (~30 seconds). On success, the homebrew tap formula (`carme99/homebrew-tap/mac-cleans.rb`) is updated and a GitHub release is created.
@@ -77,7 +77,7 @@ Say PR #83 is a `fix:` for a Photos Library edge case:
    git add CHANGELOG.md README.md docs/README.md   # the files you edited in step 2
    git commit -m "chore: bump version to v5.5.3"
    git tag v5.5.3
-   git push origin v5.5.3
+   git push origin main v5.5.3
    ```
 4. Watch Actions. 30 seconds later, `brew upgrade mac-cleans` picks up v5.5.3.
 

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -14,7 +14,7 @@ A version bump touches exactly four files, all in the same commit:
 
 | File | What changes |
 |---|---|
-| `clean-mac-space.sh` | `VERSION="X.Y.Z"` (line 7) |
+| `clean-mac-space.sh` | `VERSION="X.Y.Z"` |
 | `installer.sh` | `EXPECTED_HASH="<sha256 of clean-mac-space.sh>"` — **regenerated** by `scripts/release.sh` |
 | `CHANGELOG.md` | Move the `[Unreleased]` entry into a new `## [X.Y.Z] - YYYY-MM-DD` section |
 | `README.md` (and `docs/README.md` if it exists) | The version badge |


### PR DESCRIPTION
## What

Replaces the stale `.github/pull_request_template.md` (which used old-style "Bug fix / New feature / Documentation / Breaking change" categories) with one aligned to the project's actual conventional-commit types, and adds a new `docs/contributing/release-process.md` that codifies the "release before next PR" discipline the v5.5.2 release prep surfaced.

## Why

The v5.5.2 release took three PRs of compounding fixes before I remembered to run `scripts/release.sh` — the gap between "merge PR" and "cut release" is invisible in the current workflow. The PR template's new "Release follow-up" section makes the gate visible on every PR; the new doc explains the four version files and the step-by-step once, so I don't have to re-derive them every release.

## Changes

| File | What |
|---|---|
| `.github/pull_request_template.md` | Replaces old categories with `feat:` / `fix:` / `refactor:` / `docs:` / `chore:` (each maps to a version-bump signal). Adds self-review checklist (`bash tests/run-tests.sh`, `shellcheck`, `bash -n`, CHANGELOG `[Unreleased]`, no `.bak` files). Adds "Release follow-up" reminder section. |
| `docs/contributing/release-process.md` (new, 97 lines) | The canonical release checklist: the "release before next PR" rule, the four version files, full `scripts/release.sh` step-by-step, the manual CHANGELOG + version-badge edits, tag-push, and a v5.5.2→v5.5.3 worked example. Includes "What this is **not**" (no release-please, no pre-commit, no auto-bump) and a troubleshooting table. |
| `CONTRIBUTING.md` | Adds a one-line pointer from § Release Process to the new doc. The existing long checklist stays; it's just no longer the canonical place. |

## Self-review

- [x] `bash tests/run-tests.sh` (n/a — no script changes)
- [x] `shellcheck -S warning clean-mac-space.sh` (n/a — no script changes)
- [x] No new `*.bak` files in the diff
- [x] All relative links point to existing files (CONTRIBUTING.md, docs/reference/commands.md, docs/contributing/release-process.md)

## Release follow-up

- [ ] This PR is `docs:` — **no release needed**
- [ ] Next user-visible PR will trigger a `scripts/release.sh` run; this PR primes that gate by activating the new PR template

## Risk

Zero. Docs only, no scripts touched, no behavior change. Worst case: the new PR template is mildly annoying to fill in for a few PRs until I get used to it. The release-process doc is opt-in reading.

## Summary by Sourcery

Align pull request template and contributor docs with the project’s manual release workflow and conventional-commit types.

Documentation:
- Update the PR template to use conventional-commit categories, add a self-review checklist, and introduce a release follow-up reminder for maintainers.
- Add a detailed release-process guide documenting version bump steps, the golden rule for releasing after user-visible changes, and troubleshooting guidance.
- Clarify CONTRIBUTING.md by pointing maintainers to the new canonical release-process document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidelines and pull request template to streamline the contribution process.
  * Added comprehensive release process documentation for maintainers, including version management and workflow procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->