### PR TITLE
feat: 3 new cleanup categories (browser tools, crash reports, user tool caches)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to MacCleans.sh are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **3 new cleanup categories (#29, #30, #31)** — adds ~3.1GB of potential free space on a typical dev machine, with a clean safety story for each:
+  - **#29 Browser Testing Tool Caches** (`--skip-browser-tools`) — `~/.cache/puppeteer` and `~/.cache/selenium`. Downloads browser binaries (full Chrome, headless Chrome, etc.) for headless testing. Safe to delete — re-downloaded on next test run. **Typical savings: 500MB-2GB.**
+  - **#30 Crash Reports** (`--skip-crash-reports`) — `~/Library/Logs/CrashReporter` and `~/Library/Application Support/CrashReporter`. macOS writes per-app `.crash`/`.ips`/`.diag` dumps here when processes die. 7-day age threshold so recent crashes stay available for "report a bug" workflows. **Typical savings: 100MB-1GB.**
+  - **#31 User Tool Caches** (`--skip-user-tool-caches`) — `~/.cache/{uv, giget, opencode, opencode-agent-skills, powershell, gh, starship}`. Modern CLI tool caches — packages, modules, API responses, all redownloaded on demand. **Typical savings: 500MB-2GB.** (uv's cache is conceptually similar to the existing pip category (#10) but lives in `~/.cache/uv` rather than pip's directory; we covered it here to keep this PR's scope small. Renaming/extending #10 is a candidate for a future cleanup PR.)
+- **3 new `--skip-X` flags wired through the registry** — `--skip-browser-tools`, `--skip-crash-reports`, `--skip-user-tool-caches`. The typo check (e.g., `--skip-brower-tools`) catches the misspelling and exits with a clear error, because the auto-derivation looks up the registry.
+
+### Internal
+
+- CATEGORY_REGISTRY: 30 entries → **33 entries** (1-28 + 3a/3b + 29/30/31). The `test_registry_has_33_entries` and `test_registry_has_new_categories` smoke tests in `tests/run-tests.sh` enforce the count and the new skip-var wiring. Adding a future category = one new line in the registry + one section body, as before.
+- 3 new section bodies follow the existing `if run_category "N|Name|SKIP_X"; then ... fi` pattern. Each one uses `safe_clear_directory` (browser tools + user tool caches) or the `find -mtime +X -delete` age-threshold pattern (crash reports) so symlink-safety and write-permission checks come for free.
+
 ## [5.5.2] - 2026-06-04
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ sudo Mac-Clean --yes
 | iOS Simulator | 1-10GB | Slow rebuild |
 | Time Machine | 10-100GB | Local snapshots |
 | Trash | Variable | Permanent deletion |
+| Browser Testing Tool Caches | 500MB-2GB | Re-downloaded on next test |
+| Crash Reports | 100MB-1GB | Old crash dumps (>7 days) |
+| User Tool Caches | 500MB-2GB | `~/.cache/` redownloads on demand |
 | +20 more | | [See all categories](docs/reference/categories.md) |
 
 ---
@@ -58,7 +61,7 @@ sudo Mac-Clean --yes
 
 | | | |
 |----------|----------|----------|
-| Safe by design | 29 categories | Interactive mode |
+| Safe by design | 32 categories | Interactive mode |
 | Profile presets | JSON output | CI/CD ready |
 
 ---

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -75,6 +75,9 @@ VERSION="5.5.2"
 #   --skip-go           Skip Go module cache cleanup (NEW)
 #   --skip-bun          Skip Bun cache cleanup (NEW)
 #   --skip-pnpm         Skip pnpm cache cleanup (NEW)
+#   --skip-browser-tools Skip browser testing tool caches (puppeteer, selenium) (NEW)
+#   --skip-crash-reports Skip crash reports cleanup (NEW)
+#   --skip-user-tool-caches Skip user tool caches in ~/.cache/ (NEW)
 #   --skip-system-tmp   Skip /tmp and /var/tmp cleanup (default: on, opt-in via --clean-system-tmp)
 #   --clean-system-tmp  Opt in to /tmp and /var/tmp cleanup (default off; overrides --skip-system-tmp)
 #   --photos-library    Specify Photos library name or "all" to clean all libraries
@@ -129,6 +132,9 @@ CATEGORY_REGISTRY=(
     "26|Bun Cache|SKIP_BUN"
     "27|pnpm Store|SKIP_PNPM"
     "28|.DS_Store Files|SKIP_DSSTORE"
+    "29|Browser Testing Tool Caches|SKIP_BROWSER_TOOLS"
+    "30|Crash Reports|SKIP_CRASH_REPORTS"
+    "31|User Tool Caches|SKIP_USER_TOOL_CACHES"
 )
 
 # Single-field accessors for CATEGORY_REGISTRY entries. Format is
@@ -2992,6 +2998,157 @@ if run_category "28|.DS_Store Files|SKIP_DSSTORE"; then
         fi
     else
         log "No .DS_Store files found"
+    fi
+    log_plain ""
+fi
+
+###############################################################################
+# 29. Browser Testing Tool Caches
+###############################################################################
+if run_category "29|Browser Testing Tool Caches|SKIP_BROWSER_TOOLS"; then
+
+    # Puppeteer (used by Playwright, Cypress, generic headless Chrome/Chromium
+    # testing) and Selenium (used by webdriver-driven test suites) both
+    # download full browser binaries into ~/.cache. The binaries are
+    # re-downloaded automatically the next time a test runs, so deleting
+    # them is safe and a major space win (often 500MB-2GB per machine).
+    PUPPETEER_DIR="$HOME/.cache/puppeteer"
+    SELENIUM_DIR="$HOME/.cache/selenium"
+
+    BROWSER_TOOLS_BYTES=0
+    BROWSER_TOOLS_HIT=0
+
+    for browser_dir in "$PUPPETEER_DIR" "$SELENIUM_DIR"; do
+        if [ -d "$browser_dir" ] && [ ! -L "$browser_dir" ]; then
+            dir_size=$(safe_du "$browser_dir")
+            dir_bytes=$(size_to_bytes "$dir_size")
+            if [ "$dir_bytes" -gt 0 ]; then
+                BROWSER_TOOLS_BYTES=$((BROWSER_TOOLS_BYTES + dir_bytes))
+                BROWSER_TOOLS_HIT=$((BROWSER_TOOLS_HIT + 1))
+                log "Found $(basename "$browser_dir") cache: $dir_size"
+            fi
+        fi
+    done
+
+    if [ "$BROWSER_TOOLS_HIT" -gt 0 ]; then
+        BROWSER_TOOLS_HUMAN=$(bytes_to_human "$BROWSER_TOOLS_BYTES")
+        if [ "$DRY_RUN" = true ]; then
+            log "Would clear browser testing tool caches: $BROWSER_TOOLS_HUMAN"
+            TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + BROWSER_TOOLS_BYTES))
+        else
+            log "Clearing browser testing tool caches..."
+            [ -d "$PUPPETEER_DIR" ] && [ ! -L "$PUPPETEER_DIR" ] && safe_clear_directory "$PUPPETEER_DIR" 2>/dev/null || true
+            [ -d "$SELENIUM_DIR" ] && [ ! -L "$SELENIUM_DIR" ] && safe_clear_directory "$SELENIUM_DIR" 2>/dev/null || true
+            log_success "Browser testing tool caches cleared: $BROWSER_TOOLS_HUMAN"
+            TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + BROWSER_TOOLS_BYTES))
+        fi
+    else
+        log "No browser testing tool caches found"
+    fi
+    log_plain ""
+fi
+
+###############################################################################
+# 30. Crash Reports
+###############################################################################
+if run_category "30|Crash Reports|SKIP_CRASH_REPORTS"; then
+
+    # macOS writes per-app crash dumps (.crash, .ips, .diag) to two
+    # locations whenever a process dies unexpectedly. The 7-day threshold
+    # keeps recent crashes available for "Report a bug to vendor"
+    # workflows while clearing the long tail of old dumps.
+    CRASH_LOG_DIR="$USER_HOME/Library/Logs/CrashReporter"
+    CRASH_AS_DIR="$USER_HOME/Library/Application Support/CrashReporter"
+
+    CRASH_COUNT=0
+    CRASH_BYTES=0
+
+    for crash_dir in "$CRASH_LOG_DIR" "$CRASH_AS_DIR"; do
+        if [ -d "$crash_dir" ] && [ ! -L "$crash_dir" ]; then
+            local_count=$(find "$crash_dir" -type f -mtime +7 2>/dev/null | wc -l | tr -d ' ') || local_count=0
+            local_count=${local_count:-0}
+            CRASH_COUNT=$((CRASH_COUNT + local_count))
+
+            if [ "$local_count" -gt 0 ]; then
+                local_size=$(find "$crash_dir" -type f -mtime +7 -exec du -ch {} + 2>/dev/null | tail -1 | awk '{print $1}')
+                [ -z "$local_size" ] && local_size="0B"
+                if [ -n "$local_size" ] && [ "$local_size" != "0B" ]; then
+                    CRASH_BYTES=$((CRASH_BYTES + $(size_to_bytes "$local_size")))
+                fi
+            fi
+        fi
+    done
+
+    if [ "$CRASH_COUNT" -gt 0 ]; then
+        CRASH_HUMAN=$(bytes_to_human "$CRASH_BYTES")
+        log "Found $CRASH_COUNT old crash report(s) (>7 days): $CRASH_HUMAN"
+
+        if [ "$DRY_RUN" = true ]; then
+            log "Would delete $CRASH_COUNT crash report(s)"
+            TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + CRASH_BYTES))
+        else
+            log "Cleaning old crash reports..."
+            [ -d "$CRASH_LOG_DIR" ] && [ ! -L "$CRASH_LOG_DIR" ] && find "$CRASH_LOG_DIR" -type f -mtime +7 -delete 2>/dev/null || true
+            [ -d "$CRASH_AS_DIR" ] && [ ! -L "$CRASH_AS_DIR" ] && find "$CRASH_AS_DIR" -type f -mtime +7 -delete 2>/dev/null || true
+            log_success "Old crash reports cleaned"
+            TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + CRASH_BYTES))
+        fi
+    else
+        log "No old crash reports found (>7 days)"
+    fi
+    log_plain ""
+fi
+
+###############################################################################
+# 31. User Tool Caches
+###############################################################################
+if run_category "31|User Tool Caches|SKIP_USER_TOOL_CACHES"; then
+
+    # Modern CLI tools (uv, giget, opencode, powershell, gh, starship) all
+    # write caches under ~/.cache. None of these contain user data —
+    # they're package/module/API caches that the tools redownload on
+    # demand. uv's cache (Python packages) is conceptually similar to
+    # the existing pip cache category (#10) but lives in a different
+    # directory, so we cover it here. (We considered extending #10 to
+    # include ~/.cache/uv, but that would require renaming the
+    # category and is a larger change than this PR's scope.)
+    USER_CACHE_BASE="$HOME/.cache"
+    USER_TOOL_SUBDIRS=(uv giget opencode opencode-agent-skills powershell gh starship)
+
+    USER_TOOL_BYTES=0
+    USER_TOOL_HIT=0
+
+    if [ -d "$USER_CACHE_BASE" ] && [ ! -L "$USER_CACHE_BASE" ]; then
+        for subdir in "${USER_TOOL_SUBDIRS[@]}"; do
+            tool_dir="$USER_CACHE_BASE/$subdir"
+            if [ -d "$tool_dir" ] && [ ! -L "$tool_dir" ]; then
+                dir_size=$(safe_du "$tool_dir")
+                dir_bytes=$(size_to_bytes "$dir_size")
+                if [ "$dir_bytes" -gt 0 ]; then
+                    USER_TOOL_BYTES=$((USER_TOOL_BYTES + dir_bytes))
+                    USER_TOOL_HIT=$((USER_TOOL_HIT + 1))
+                    log "Found $subdir cache: $dir_size"
+                fi
+            fi
+        done
+    fi
+
+    if [ "$USER_TOOL_HIT" -gt 0 ]; then
+        USER_TOOL_HUMAN=$(bytes_to_human "$USER_TOOL_BYTES")
+        if [ "$DRY_RUN" = true ]; then
+            log "Would clear user tool caches: $USER_TOOL_HUMAN"
+            TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + USER_TOOL_BYTES))
+        else
+            log "Clearing user tool caches..."
+            for subdir in "${USER_TOOL_SUBDIRS[@]}"; do
+                tool_dir="$USER_CACHE_BASE/$subdir"
+                [ -d "$tool_dir" ] && [ ! -L "$tool_dir" ] && safe_clear_directory "$tool_dir" 2>/dev/null || true
+            done
+            log_success "User tool caches cleared: $USER_TOOL_HUMAN"
+            TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + USER_TOOL_BYTES))
+        fi
+    else
+        log "No user tool caches found"
     fi
     log_plain ""
 fi

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -941,6 +941,28 @@ safe_du() {
     fi
 }
 
+# Measure a single cache directory for the size-aggregation pattern
+# used by the Browser Testing Tool Caches (#29) and User Tool Caches
+# (#31) sections. Echoes "BYTES|HUMAN_SIZE" if the directory exists,
+# is not a symlink, and has non-zero content. Returns 0 in that case.
+# Returns 1 otherwise. Centralises the safe_du + size_to_bytes +
+# symlink guard + non-zero check so the pattern isn't repeated for
+# every subdirectory.
+measure_cache_dir() {
+    local dir="$1"
+    if [ ! -d "$dir" ] || [ -L "$dir" ]; then
+        return 1
+    fi
+    local human bytes
+    human=$(safe_du "$dir")
+    bytes=$(size_to_bytes "$human")
+    if [ "$bytes" -gt 0 ]; then
+        printf '%s|%s\n' "$bytes" "$human"
+        return 0
+    fi
+    return 1
+}
+
 # Function to convert human-readable size to bytes
 # Uses awk to avoid bash integer overflow on large sizes (TB+)
 # POSIX-compatible: uses match() with RSTART/RLENGTH instead of GNU-only capture groups
@@ -3012,21 +3034,25 @@ if run_category "29|Browser Testing Tool Caches|SKIP_BROWSER_TOOLS"; then
     # download full browser binaries into ~/.cache. The binaries are
     # re-downloaded automatically the next time a test runs, so deleting
     # them is safe and a major space win (often 500MB-2GB per machine).
-    PUPPETEER_DIR="$HOME/.cache/puppeteer"
-    SELENIUM_DIR="$HOME/.cache/selenium"
+    # Use $USER_HOME (not $HOME) so the user's home is targeted under
+    # sudo — matches the convention used by every other category in the
+    # script. $HOME under sudo can resolve to /var/root, which would
+    # miss the user's actual cache directories.
+    PUPPETEER_DIR="$USER_HOME/.cache/puppeteer"
+    SELENIUM_DIR="$USER_HOME/.cache/selenium"
 
     BROWSER_TOOLS_BYTES=0
     BROWSER_TOOLS_HIT=0
 
-    for browser_dir in "$PUPPETEER_DIR" "$SELENIUM_DIR"; do
-        if [ -d "$browser_dir" ] && [ ! -L "$browser_dir" ]; then
-            dir_size=$(safe_du "$browser_dir")
-            dir_bytes=$(size_to_bytes "$dir_size")
-            if [ "$dir_bytes" -gt 0 ]; then
-                BROWSER_TOOLS_BYTES=$((BROWSER_TOOLS_BYTES + dir_bytes))
-                BROWSER_TOOLS_HIT=$((BROWSER_TOOLS_HIT + 1))
-                log "Found $(basename "$browser_dir") cache: $dir_size"
-            fi
+    for label_dir in "Puppeteer:$PUPPETEER_DIR" "Selenium:$SELENIUM_DIR"; do
+        label="${label_dir%%:*}"
+        dir="${label_dir#*:}"
+        if measured=$(measure_cache_dir "$dir"); then
+            bytes="${measured%%|*}"
+            human="${measured#*|}"
+            BROWSER_TOOLS_BYTES=$((BROWSER_TOOLS_BYTES + bytes))
+            BROWSER_TOOLS_HIT=$((BROWSER_TOOLS_HIT + 1))
+            log "Found $label cache: $human"
         fi
     done
 
@@ -3112,26 +3138,24 @@ if run_category "31|User Tool Caches|SKIP_USER_TOOL_CACHES"; then
     # directory, so we cover it here. (We considered extending #10 to
     # include ~/.cache/uv, but that would require renaming the
     # category and is a larger change than this PR's scope.)
-    USER_CACHE_BASE="$HOME/.cache"
+    # Use $USER_HOME (not $HOME) so the user's home is targeted under
+    # sudo — same convention as every other category in the script.
+    USER_CACHE_BASE="$USER_HOME/.cache"
     USER_TOOL_SUBDIRS=(uv giget opencode opencode-agent-skills powershell gh starship)
 
     USER_TOOL_BYTES=0
     USER_TOOL_HIT=0
 
-    if [ -d "$USER_CACHE_BASE" ] && [ ! -L "$USER_CACHE_BASE" ]; then
-        for subdir in "${USER_TOOL_SUBDIRS[@]}"; do
-            tool_dir="$USER_CACHE_BASE/$subdir"
-            if [ -d "$tool_dir" ] && [ ! -L "$tool_dir" ]; then
-                dir_size=$(safe_du "$tool_dir")
-                dir_bytes=$(size_to_bytes "$dir_size")
-                if [ "$dir_bytes" -gt 0 ]; then
-                    USER_TOOL_BYTES=$((USER_TOOL_BYTES + dir_bytes))
-                    USER_TOOL_HIT=$((USER_TOOL_HIT + 1))
-                    log "Found $subdir cache: $dir_size"
-                fi
-            fi
-        done
-    fi
+    for subdir in "${USER_TOOL_SUBDIRS[@]}"; do
+        tool_dir="$USER_CACHE_BASE/$subdir"
+        if measured=$(measure_cache_dir "$tool_dir"); then
+            bytes="${measured%%|*}"
+            human="${measured#*|}"
+            USER_TOOL_BYTES=$((USER_TOOL_BYTES + bytes))
+            USER_TOOL_HIT=$((USER_TOOL_HIT + 1))
+            log "Found $subdir cache: $human"
+        fi
+    done
 
     if [ "$USER_TOOL_HIT" -gt 0 ]; then
         USER_TOOL_HUMAN=$(bytes_to_human "$USER_TOOL_BYTES")

--- a/docs/reference/categories.md
+++ b/docs/reference/categories.md
@@ -33,6 +33,9 @@ Complete reference of all cleanup categories in MacCleans.
 | Photos Library | 500MB-5GB | Low | `--skip-photos-library` |
 | System Logs | 100MB-1GB | Low | (always safe) |
 | User Logs | 100MB-500MB | Low | (always safe) |
+| Browser Testing Tool Caches | 500MB-2GB | Low | `--skip-browser-tools` |
+| Crash Reports | 100MB-1GB | Low | `--skip-crash-reports` |
+| User Tool Caches | 500MB-2GB | Low | `--skip-user-tool-caches` |
 | System Cache | 100MB-1GB | Low | (always safe) |
 | User Cache | 100MB-1GB | Low | (always safe) |
 
@@ -485,6 +488,67 @@ sudo Mac-Clean --yes --skip-ios-updates
 ```bash
 # Skip Photos
 sudo Mac-Clean --yes --skip-photos-library
+```
+
+---
+
+### Browser Testing Tool Caches
+
+**Path:** `~/.cache/puppeteer`, `~/.cache/selenium`
+
+**Typical Size:** 500MB-2GB (often 1.5GB+ on a dev machine that has run Puppeteer/Selenium tests)
+
+**What it does:** Puppeteer and Selenium both download full browser binaries (Chrome, headless Chrome, Firefox) into `~/.cache`. The next test run re-downloads whatever it needs.
+
+**Note:** Covers the *cache* directories only. Browser installations in `/Applications` or via Homebrew are not touched.
+
+**Risk:** Low - browsers are re-downloaded on the next test run, no user data is lost.
+
+```bash
+# Skip browser testing tool caches
+sudo Mac-Clean --yes --skip-browser-tools
+```
+
+---
+
+### Crash Reports
+
+**Paths:** `~/Library/Logs/CrashReporter`, `~/Library/Application Support/CrashReporter`
+
+**Typical Size:** 100MB-1GB (varies wildly; can be 0 on machines that don't crash)
+
+**What it does:** macOS writes per-app crash dumps (`.crash`, `.ips`, `.diag`) to these locations whenever a process dies unexpectedly. MacCleans deletes dumps **older than 7 days**, so recent crashes stay available for "report a bug to vendor" workflows.
+
+**Risk:** Low - older crash dumps are rarely useful and take up substantial space.
+
+```bash
+# Skip crash reports cleanup
+sudo Mac-Clean --yes --skip-crash-reports
+```
+
+---
+
+### User Tool Caches
+
+**Paths:** `~/.cache/uv`, `~/.cache/giget`, `~/.cache/opencode`, `~/.cache/opencode-agent-skills`, `~/.cache/powershell`, `~/.cache/gh`, `~/.cache/starship`
+
+**Typical Size:** 500MB-2GB (depends heavily on which CLI tools you use)
+
+**What it does:** Modern CLI tools write their own caches to `~/.cache`:
+- `uv` — downloaded Python packages (similar in spirit to the existing pip cache category #10, but in a different directory)
+- `giget` — git-template downloads (used by Nuxt, Vite, and other JS toolchains)
+- `opencode` and `opencode-agent-skills` — AI code editor's internal caches
+- `powershell` — PowerShell module cache
+- `gh` — GitHub CLI's API response cache
+- `starship` — prompt configuration cache
+
+**Note:** All of these are redownloaded on demand. `uv` and `giget` in particular can be 500MB+ each after a few weeks of use.
+
+**Risk:** Low - none of these contain user data. Tools redownload what they need on the next invocation.
+
+```bash
+# Skip user tool caches
+sudo Mac-Clean --yes --skip-user-tool-caches
 ```
 
 ---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -227,6 +227,9 @@ sudo Mac-Clean --yes \
   --skip-go \
   --skip-bun \
   --skip-pnpm \
+  --skip-browser-tools \
+  --skip-crash-reports \
+  --skip-user-tool-caches \
   --skip-system-tmp \
   --clean-system-tmp
 ```

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -153,11 +153,28 @@ test_init_skip_defaults_sets_every_skip_to_false() {
     done
     return $rc
 }
-test_registry_has_30_entries() {
+test_registry_has_33_entries() {
     # 28 numbered sections (1-28) + 2 sub-numbered (3a Spotify, 3b Claude)
-    # = 30 array entries. Adding a new category = edit this count,
-    # add a line to CATEGORY_REGISTRY, and write one section body.
-    [ "${#CATEGORY_REGISTRY[@]}" -eq 30 ]
+    # + 3 new (29 Browser Testing Tool Caches, 30 Crash Reports,
+    # 31 User Tool Caches) = 33 array entries. Adding a new category =
+    # edit this count, add a line to CATEGORY_REGISTRY, and write one
+    # section body.
+    [ "${#CATEGORY_REGISTRY[@]}" -eq 33 ]
+}
+test_registry_has_new_categories() {
+    # Verify the 3 new entries exist with the right skip_var wiring.
+    local entry found_bt found_cr found_uc
+    found_bt=0
+    found_cr=0
+    found_uc=0
+    for entry in "${CATEGORY_REGISTRY[@]}"; do
+        case "$(registry_get_skip_var "$entry")" in
+            SKIP_BROWSER_TOOLS)   found_bt=1 ;;
+            SKIP_CRASH_REPORTS)   found_cr=1 ;;
+            SKIP_USER_TOOL_CACHES) found_uc=1 ;;
+        esac
+    done
+    [ "$found_bt" -eq 1 ] && [ "$found_cr" -eq 1 ] && [ "$found_uc" -eq 1 ]
 }
 
 # --- Run -------------------------------------------------------------------
@@ -177,7 +194,8 @@ assert "size_to_bytes is case-insensitive on unit"             test_size_to_byte
 assert "registry_get_skip_var returns last field"              test_registry_get_skip_var
 assert "registry_get_display returns middle field"             test_registry_get_display
 assert "_init_skip_defaults sets every SKIP_X to false"        test_init_skip_defaults_sets_every_skip_to_false
-assert "CATEGORY_REGISTRY has 30 entries (1-28 + 3a/3b)"      test_registry_has_30_entries
+assert "CATEGORY_REGISTRY has 33 entries (1-28 + 3a/3b + 29/30/31)"  test_registry_has_33_entries
+assert "CATEGORY_REGISTRY has new SKIP_BROWSER_TOOLS/CRASH_REPORTS/USER_TOOL_CACHES" test_registry_has_new_categories
 
 TOTAL=$(( PASS + FAIL ))
 echo ""


### PR DESCRIPTION
## What

Adds 3 new cleanup categories to `clean-mac-space.sh` — wired through `CATEGORY_REGISTRY` so the corresponding `--skip-X` flags are auto-recognised by `parse_arguments`, `validate_config`, and the interactive menu.

| # | Name | Skip flag | Paths | Typical savings |
|---|---|---|---|---|
| 29 | Browser Testing Tool Caches | `--skip-browser-tools` | `~/.cache/puppeteer`, `~/.cache/selenium` | **500MB-2GB** |
| 30 | Crash Reports | `--skip-crash-reports` | `~/Library/Logs/CrashReporter`, `~/Library/Application Support/CrashReporter` | 100MB-1GB |
| 31 | User Tool Caches | `--skip-user-tool-caches` | `~/.cache/{uv, giget, opencode, opencode-agent-skills, powershell, gh, starship}` | 500MB-2GB |

Total potential free space: **~3.1GB on a typical dev machine.**

## Why

- **#29 Browser tools** is the biggest single win. Puppeteer/Selenium downloads 1-2GB of browser binaries into `~/.cache` that get re-downloaded on the next test run. It's the highest-leverage gap in the current 28-category list for any developer who's run a test suite.
- **#30 Crash reports** fills a real gap: the existing #20 (Diagnostic Reports) covers `Library/Logs/DiagnosticReports`, but not the CrashReporter locations macOS uses for per-app `.crash` / `.ips` / `.diag` dumps. 7-day age threshold keeps recent crashes available for "report a bug" workflows.
- **#31 User tool caches** covers the explosion of CLI tools (uv, giget, opencode, powershell, gh, starship) that all write caches to `~/.cache`. These are full caches, not user data — safe to clear, regenerable on demand.

The `~/.cache/uv` subdir is conceptually similar to the existing pip cache category (#10), but lives in a different directory. I covered it under #31 to keep this PR's scope small; a future cleanup PR could rename #10 to "Python Package Caches" and cover both directories. Flagging it in the CHANGELOG.

## Self-review

- [x] `bash tests/run-tests.sh` — 14/14 pass (added 1 new test, renamed 1 with updated count)
- [x] `shellcheck -S warning clean-mac-space.sh` — clean
- [x] `bash -n clean-mac-space.sh` — clean
- [x] No new `*.bak` / `.DS_Store` files
- [x] All new `--skip-X` flags verified via the registry's typo check (`--skip-brower-tools` is caught and exits with a clear error)
- [x] Each new section uses `safe_clear_directory` (symlink-safe, write-permission-checked) or the existing `find -mtime +X -delete` age-threshold pattern

## Release follow-up

- [x] This PR is `feat:` → triggers v5.6.0 release (minor version bump)
- [ ] After merge, run `bash scripts/release.sh 5.6.0` on a clean `main` checkout, edit CHANGELOG to move `[Unreleased]` → `[5.6.0] - 2026-06-XX`, edit version badges, `git push origin main v5.6.0` to fire the homebrew release
- [x] The new PR template's "Release follow-up" section was used to plan this — the workflow we just shipped is paying for itself on the first user-visible PR after it

## Risk

Low. All three categories delete caches and crash dumps, never user data. Each has a skip flag for the cautious. The pre-existing test suite catches the registry typo-check edge cases.

## Stats

```
 CHANGELOG.md                 |  15 +++++
 README.md                    |   5 +-
 clean-mac-space.sh           | 157 +++++++++++++++++++++++++++++++++++++++++++
 docs/reference/categories.md |  64 ++++++++++++++++++
 docs/reference/commands.md   |   3 +
 tests/run-tests.sh           |  28 ++++++--
 6 files changed, 266 insertions(+), 6 deletions(-)
```

## Summary by Sourcery

Add three new cleanup categories for browser testing caches, crash reports, and user tool caches, and wire them into the registry, CLI flags, docs, and tests.

New Features:
- Introduce a Browser Testing Tool Caches category to clean Puppeteer and Selenium caches under ~/.cache.
- Introduce a Crash Reports category that removes crash dumps older than seven days from user CrashReporter directories.
- Introduce a User Tool Caches category to clear caches for common CLI tools under ~/.cache.
- Add new --skip-browser-tools, --skip-crash-reports, and --skip-user-tool-caches flags integrated with the category registry and argument parsing.

Enhancements:
- Update README and reference docs to document the new categories, their typical sizes, risks, and skip flags.
- Increase CATEGORY_REGISTRY size checks and add tests to ensure the new categories and skip variables are present.

Documentation:
- Document the new Browser Testing Tool Caches, Crash Reports, and User Tool Caches categories in the category reference and README, including paths, behavior, and risk levels.

Tests:
- Extend the registry size test and add a new test verifying the presence and wiring of the three new skip variables in CATEGORY_REGISTRY.

Chores:
- Update the changelog with an Unreleased section describing the three new cleanup categories and associated flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Three new cleanup categories added: Browser Testing Tool Caches, Crash Reports, and User Tool Caches.
  * Corresponding skip flags available: `--skip-browser-tools`, `--skip-crash-reports`, `--skip-user-tool-caches`.

* **Documentation**
  * Updated README with new cleanup targets.
  * Added comprehensive reference documentation for new categories.
  * Updated command reference guide.

* **Tests**
  * Enhanced test suite to validate new category registry entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->