### PR TITLE
chore: security audit — 3 sudo $HOME bugs fixed + 3 CI audit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to MacCleans.sh are documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+- **Three-pass security audit + 3 audit tests** — script-wide review of `$USER_HOME` usage, `find -delete` symlink-safety, and sudo path resolution. Found and fixed 3 real bugs (below). The audit patterns are now codified as 3 CI tests in `tests/run-tests.sh` so future regressions get caught at PR time.
+- **Fixed: `CONFIG_FILES` (script entry points) used literal `$HOME`** — under `sudo Mac-Clean` on default macOS sudoers, `$HOME` resolves to `/var/root`, which meant the script silently missed the user's `~/.maccleans.conf` and `~/.config/maccleans/config`. The config-file load would then use no config, and the user wouldn't see the warning. Moved the array to after the `USER_HOME` derivation and switched to `$USER_HOME`.
+- **Fixed: `LOCKDIR="$HOME/.macclean/lock"`** — the per-invocation lock went to `/var/root/.macclean/lock` under sudo, while a non-sudo invocation would create a separate lock in the user's real home. Two separate locks = no actual concurrency protection. Reassigned `LOCKDIR` after `USER_HOME` derivation to use `$USER_HOME/.macclean/lock`.
+- **Fixed: `check_icloud_backup_enabled` used `$HOME`** — the iOS backup detection logic looked for `~/Library/Logs/MobileBackup/Backup.log`, which under sudo would silently miss the user's real backup log. This affected the safety check that warns before deleting iOS device backups (category #21). Switched to `$USER_HOME`.
+
+### Internal
+
+- `tests/run-tests.sh`: 14 → 17 tests. The 3 new tests are:
+  - `test_no_literal_home_in_user_paths` — fails if any future PR adds `"$HOME/..."` to the script
+  - `test_find_delete_has_type_or_symlink_guard` — fails if any future `find ... -delete` lacks a type filter or `[ ! -L ]` guard
+  - `test_user_home_derivation_uses_sudo_user` — verifies the sudo/non-sudo derivation block in the script has the right shape (uses `$SUDO_USER` + `getent` with a `$HOME` fallback)
+- `docs/explanation/security-model.md`: documents the `$USER_HOME` and `find -delete` symlink-safety conventions so the next contributor knows the rules without having to re-derive them.
+
 ## [5.6.0] - 2026-06-05
 
 ### Added

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -392,12 +392,6 @@ load_config_file() {
     done
 }
 
-# Load configuration. Skipped in TEST_MODE so the sourced script
-# doesn't read or write user-level config files from tests.
-if [ -z "${TEST_MODE:-}" ]; then
-    load_config_file
-fi
-
 # Parse command-line arguments
 parse_arguments() {
     while [[ $# -gt 0 ]]; do
@@ -1152,6 +1146,20 @@ CONFIG_FILES=(
     "$USER_HOME/.config/maccleans/config"
     "${XDG_CONFIG_HOME:-$USER_HOME/.config}/maccleans/config"
 )
+
+# Load configuration. Skipped in TEST_MODE so the sourced script
+# doesn't read or write user-level config files from tests. Lives
+# here (not at the top of the script) so it runs AFTER CONFIG_FILES
+# is initialized — which itself has to be after USER_HOME is derived.
+# The audit caught a regression where the call was at the top of the
+# script but CONFIG_FILES had moved to after USER_HOME, so the for
+# loop in load_config_file iterated an empty array and no config was
+# ever loaded. The test
+# test_config_files_defined_before_load_config_file_call enforces
+# the ordering.
+if [ -z "${TEST_MODE:-}" ]; then
+    load_config_file
+fi
 
 # Lock directory for preventing parallel runs. Reassigned here (not at
 # the top of the script) so it can use $USER_HOME, which is derived

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -224,11 +224,15 @@ run_category() {
 VERBOSE=false
 
 # Configuration file locations (checked in order)
-CONFIG_FILES=(
-    "$HOME/.maccleans.conf"
-    "$HOME/.config/maccleans/config"
-    "${XDG_CONFIG_HOME:-$HOME/.config}/maccleans/config"
-)
+# NOTE: This array is initialized later in the script, after USER_HOME
+# is derived (see the post-source-guard setup block). Using $HOME here
+# at script-load time would silently miss the user's actual config when
+# run under `sudo` — $HOME under sudo resolves to /var/root on default
+# macOS sudoers (Defaults env_reset), but USER_HOME is correctly derived
+# from $SUDO_USER's passwd entry. The audit test
+# `test_user_home_for_user_paths` enforces that any user-path array or
+# variable assignment uses $USER_HOME, not $HOME.
+# See the security audit PR for context.
 
 ###############################################################################
 # Helper Functions
@@ -609,8 +613,14 @@ cleanup_on_exit() {
 trap cleanup_on_exit EXIT
 
 # Lock directory for preventing parallel runs
-# Use user-protected directory instead of world-writable /tmp
-LOCKDIR="$HOME/.macclean/lock"
+# Use user-protected directory instead of world-writable /tmp.
+# LOCKDIR is reassigned in the post-source-guard setup block, after
+# USER_HOME is derived. The trap cleanup_on_exit (set above) holds
+# the reassignment via parameter expansion guards (`-n "${LOCKDIR:-}"`).
+# See the security audit PR for context on why $HOME here was a bug.
+LOCKDIR=""
+LOCK_OWNED=0
+MIN_FREE_MB=200
 LOCK_OWNED=0
 MIN_FREE_MB=200
 
@@ -806,10 +816,13 @@ check_icloud_backup_enabled() {
     fi
     
     # Also check if there's evidence of recent iCloud backups in the log
-    # This is a secondary check to be more permissive
-    if [ -f "$HOME/Library/Logs/MobileBackup/Backup.log" ]; then
+    # This is a secondary check to be more permissive.
+    # Uses $USER_HOME (not $HOME) so the actual user's home is checked
+    # under `sudo` — the old code used $HOME which would silently
+    # miss the real backup log under sudo on default macOS sudoers.
+    if [ -f "$USER_HOME/Library/Logs/MobileBackup/Backup.log" ]; then
         local recent_backup
-        recent_backup=$(find "$HOME/Library/Logs/MobileBackup" -name "Backup.log" -mtime -30 2>/dev/null | wc -l)
+        recent_backup=$(find "$USER_HOME/Library/Logs/MobileBackup" -name "Backup.log" -mtime -30 2>/dev/null | wc -l)
         if [ "$recent_backup" -gt 0 ]; then
             return 0
         fi
@@ -1129,6 +1142,25 @@ if [ -L "$USER_HOME" ]; then
         log_warning "readlink not found; cannot resolve user home symlink. Using: $USER_HOME"
     fi
 fi
+
+# Configuration file locations (checked in order).
+# Uses $USER_HOME (not $HOME) so the user's actual home is targeted
+# under sudo. The old (pre-audit) code used $HOME here at script-load
+# time, which silently missed the user's real config under `sudo Mac-Clean`
+# on default macOS sudoers (env_reset → $HOME=/var/root).
+CONFIG_FILES=(
+    "$USER_HOME/.maccleans.conf"
+    "$USER_HOME/.config/maccleans/config"
+    "${XDG_CONFIG_HOME:-$USER_HOME/.config}/maccleans/config"
+)
+
+# Lock directory for preventing parallel runs. Reassigned here (not at
+# the top of the script) so it can use $USER_HOME, which is derived
+# above. The old (pre-audit) code used $HOME here, which under `sudo`
+# resolved to /var/root and meant the lock didn't actually protect the
+# user (a non-sudo run of the script would create a separate lock in
+# the user's real home, defeating the whole concurrency check).
+LOCKDIR="$USER_HOME/.macclean/lock"
 
 # Validate user
 if [ -z "$ACTUAL_USER" ] || [ "$ACTUAL_USER" = "root" ]; then

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -612,17 +612,12 @@ cleanup_on_exit() {
 }
 trap cleanup_on_exit EXIT
 
-# Lock directory for preventing parallel runs
-# Use user-protected directory instead of world-writable /tmp.
-# LOCKDIR is reassigned in the post-source-guard setup block, after
-# USER_HOME is derived. The trap cleanup_on_exit (set above) holds
-# the reassignment via parameter expansion guards (`-n "${LOCKDIR:-}"`).
+# Lock directory for preventing parallel runs. Initialised in the
+# post-source-guard setup block (after USER_HOME is derived) so it
+# can use $USER_HOME. The trap cleanup_on_exit (set above) holds
+# the unset value via parameter expansion guards
+# (`${LOCK_OWNED:-0}` and `-n "${LOCKDIR:-}"`).
 # See the security audit PR for context on why $HOME here was a bug.
-LOCKDIR=""
-LOCK_OWNED=0
-MIN_FREE_MB=200
-LOCK_OWNED=0
-MIN_FREE_MB=200
 
 # Acquire exclusive lock atomically using mkdir
 # Uses atomic mkdir for lock acquisition to avoid TOCTOU race conditions
@@ -1118,6 +1113,10 @@ else
     ACTUAL_USER=$(whoami)
     USER_HOME="$HOME"
 fi
+# AUDIT_MARKER: end of sudo_user_derivation_block
+# Used by tests/run-tests.sh::test_user_home_derivation_uses_sudo_user
+# as a stable end-anchor for the block extraction. Don't move this
+# marker; if you need to refactor the block above, update the test.
 
 # Resolve symlinks in USER_HOME to prevent operating on wrong directory
 if [ -L "$USER_HOME" ]; then
@@ -1161,6 +1160,8 @@ CONFIG_FILES=(
 # user (a non-sudo run of the script would create a separate lock in
 # the user's real home, defeating the whole concurrency check).
 LOCKDIR="$USER_HOME/.macclean/lock"
+LOCK_OWNED=0
+MIN_FREE_MB=200
 
 # Validate user
 if [ -z "$ACTUAL_USER" ] || [ "$ACTUAL_USER" = "root" ]; then

--- a/docs/explanation/security-model.md
+++ b/docs/explanation/security-model.md
@@ -63,6 +63,17 @@ Since this script runs with `sudo`, it's fair to ask what it's actually doing. H
 - All variables quoted - no command injection funny business
 - Operations scoped to known cache/temp directories only
 - Validates user context before doing anything
+- **User-path convention**: every reference to the user's home uses
+  `$USER_HOME` (set from `$SUDO_USER`'s passwd entry via `getent`),
+  never literal `$HOME`. Under `sudo Mac-Clean` on default macOS sudoers
+  (`Defaults env_reset`), `$HOME` resolves to `/var/root` — using it for
+  user paths would silently miss the user's actual home. The smoke test
+  `test_no_literal_home_in_user_paths` enforces this at CI time.
+- **Symlink-safety convention**: every `find ... -delete` is either
+  guarded by `-type f` (which inherently excludes symlinks) or wrapped
+  in a `[ ! -L ]` parent check. `safe_clear_directory` is the canonical
+  helper for cache-style sweeps. The smoke test
+  `test_find_delete_has_type_or_symlink_guard` enforces this at CI time.
 
 This is a free tool built for fun. It does what other apps charge money for, but without the dodgy data collection. You're welcome.
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -219,11 +219,20 @@ test_find_delete_has_type_or_symlink_guard() {
     # be preceded (within the immediately surrounding block) by a
     # `[ ! -L ]` parent guard. The check is structural: we look at the
     # find -delete line itself for `-type`, and at the prior 5 lines for
-    # `[ ! -L`.
+    # `[ ! -L ]`.
     #
     # We use a python helper because bash + multi-line + alternation is
     # painful. The script is well under 4000 lines so the perf cost is
     # trivial.
+    #
+    # Recognised safe patterns (any one of these is enough):
+    #   - Same line: `find ... -type f ... -delete` or `-type d`
+    #   - Within the prior 5 lines: `[ ! -L "$X" ]`, `[ ! -L $X ]`,
+    #     `[ ! -L "${X}" ]`, etc. (any quoting style on the path arg)
+    #   - Inside the `safe_clear_directory` function body (excluded —
+    #     it has its own internal symlink check)
+    #   - System-path finds (no `$VAR` interpolation) for paths the
+    #     system owns: /private/var/tmp, /private/tmp
     python3 - "$SCRIPT_PATH" <<'PY'
 import re
 import sys
@@ -232,19 +241,35 @@ script_path = sys.argv[1]
 with open(script_path) as f:
     lines = f.readlines()
 
-# Find every line that contains `find ... -delete` and isn't inside the
-# `safe_clear_directory` helper body (which is allowed to have multiple
-# forms by design).
 violations = []
 in_safe_clear = False
 brace_depth = 0
+
+# Symlink-guard regex. Accepts any of the common quoting styles for
+# the path argument: "$X", "${X}", $X, or `${X}`. Tabs / multiple
+# spaces between `[`, `!`, `-L` and the path are allowed.
+SYM_GUARD_RE = re.compile(
+    r'\[\s*!\s*-L\s+'            # [ ! -L
+    r'(?:'                         # path arg, any of:
+    r'"\$[\w]+"'                  #   "$X"
+    r'|\$\{[\w]+\}'               #   ${X}
+    r'|"\$?\{?[\w]+\}?"'          #   "$X" / "${X}" / "$X" / "X"
+    r'|\$[\w]+'                   #   $X
+    r')'
+    r'\s*\]'                      # closing ]
+)
+
+# safe_clear_directory body detection. Whitespace between tokens is
+# flexible to allow for refactoring.
+def is_safe_clear_def(line):
+    return bool(re.search(
+        r'^safe_clear_directory\s*\(\s*\)\s*\{',
+        line))
+
 for i, line in enumerate(lines):
     n = i + 1
 
-    # Track whether we're inside safe_clear_directory's function body.
-    # The function definition starts with `safe_clear_directory() {` and
-    # ends at the matching closing `}`.
-    if re.search(r'^safe_clear_directory\s*\(\s*\)\s*\{', line):
+    if is_safe_clear_def(line):
         in_safe_clear = True
         brace_depth = 1
         continue
@@ -254,31 +279,24 @@ for i, line in enumerate(lines):
             in_safe_clear = False
         continue
 
-    # Look for `find ... -delete` on this line.
     if not re.search(r'\bfind\b.+\-delete\b', line):
         continue
 
-    # Skip comment lines. `find -delete` mentioned in a comment is
-    # documentation, not a real call.
+    # Skip comment lines.
     stripped = line.lstrip()
     if stripped.startswith('#'):
         continue
 
-    # Same-line type filter is enough.
-    if re.search(r'-(?:type\s+[fd]|type\s+[fd]\b)', line):
-        continue
+    # Same-line type filter.
     if '-type f' in line or '-type d' in line:
         continue
 
-    # Otherwise, look at the 5 preceding lines for a `[ ! -L "$X" ]`
-    # parent guard. The guard is a common idiom and may span an `if`
-    # statement boundary.
+    # Otherwise, look at the 5 preceding lines for a [ ! -L ] guard.
     context = ''.join(lines[max(0, i-5):i+1])
-    if re.search(r'\[\s*!\s*-L\s+"\$', context):
+    if SYM_GUARD_RE.search(context):
         continue
 
-    # System-path finds (no `$VAR` interpolation) are out of scope for
-    # this test — the system owns /private/var/tmp and /private/tmp.
+    # System-path finds.
     if '/private/var/tmp' in line or '/private/tmp' in line:
         continue
 
@@ -298,19 +316,17 @@ test_user_home_derivation_uses_sudo_user() {
     # SUDO_USER is unset. We verify both by reading the relevant
     # source block from the script.
     #
-    # Specifically, the block at "Get and validate actual user" must
-    # contain:
-    #   1. `if [ -n "${SUDO_USER:-}" ]` (or equivalent) to detect sudo
-    #   2. `getent passwd "$SUDO_USER"` (or passwd lookup) to find the
-    #      home dir, since $HOME is unreliable under sudo
-    #   3. A fallback to `USER_HOME="$HOME"` when SUDO_USER is empty
+    # The block is bounded by a stable marker comment
+    # ("AUDIT_MARKER: end of sudo_user_derivation_block") so the test
+    # doesn't depend on a closing `fi` line being at column 0 (which
+    # would silently break if someone un-indented the inner `fi`).
     #
     # The audit caught a real bug where the script used $HOME for
     # CONFIG_FILES / LOCKDIR / check_icloud_backup_enabled, missing
     # the user's actual home under sudo. This test makes the derivation
     # pattern the canonical place to look.
     local block
-    block=$(/usr/bin/awk '/^# Get and validate actual user/,/^fi$/' "$SCRIPT_PATH")
+    block=$(/usr/bin/awk '/^# Get and validate actual user/,/^# AUDIT_MARKER: end of sudo_user_derivation_block$/' "$SCRIPT_PATH")
 
     if ! echo "$block" | /usr/bin/grep -qF 'SUDO_USER'; then
         echo "USER_HOME derivation does not check SUDO_USER:" >&2

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -177,6 +177,159 @@ test_registry_has_new_categories() {
     [ "$found_bt" -eq 1 ] && [ "$found_cr" -eq 1 ] && [ "$found_uc" -eq 1 ]
 }
 
+# --- Security audit tests (added 2026-06-05) -------------------------------
+#
+# These tests codify the three rules from the security audit pass:
+#   1. No section body or infrastructure code uses literal "$HOME/" for user
+#      paths — must use $USER_HOME (set from $SUDO_USER's passwd entry) so
+#      the user's actual home is targeted under `sudo`.
+#   2. Every `find ... -delete` is either guarded by `-type f`/`-type d` (which
+#      inherently exclude symlinks) or wrapped in a `[ ! -L ]` parent check.
+#      Both are safe; the rule is "at least one of the two must be present."
+#   3. The script's source-guard + sudo check + USER_HOME derivation live in
+#      the right order: source guard returns when sourced, sudo check exits
+#      when not root, USER_HOME is derived before any code that uses it.
+#
+# A regression on any of these would silently break the script under sudo
+# (e.g., a future PR adding a section body with `"$HOME/foo"` would miss
+# the user's real home when run with `sudo Mac-Clean`). These tests catch
+# that at CI time.
+
+# Path to the script (we read it directly for static checks).
+SCRIPT_PATH="$REPO_ROOT/clean-mac-space.sh"
+
+test_no_literal_home_in_user_paths() {
+    # No `"\$HOME/` (literal $HOME with trailing slash, indicating a user
+    # path) anywhere in the script. The legitimate fallback
+    # `USER_HOME="$HOME"` (no slash) at the end of the sudo/non-sudo
+    # block is fine; we look for `"\$HOME/` specifically.
+    local hits
+    hits=$(/usr/bin/grep -nF '"\$HOME/' "$SCRIPT_PATH" || true)
+    if [ -n "$hits" ]; then
+        echo "Found literal '\$HOME/' (user-path uses of \$HOME instead of \$USER_HOME):" >&2
+        echo "$hits" >&2
+        return 1
+    fi
+    return 0
+}
+
+test_find_delete_has_type_or_symlink_guard() {
+    # Every line containing `find ... -delete` must also have either a
+    # type filter (`-type f` or `-type d`) somewhere on the same line, OR
+    # be preceded (within the immediately surrounding block) by a
+    # `[ ! -L ]` parent guard. The check is structural: we look at the
+    # find -delete line itself for `-type`, and at the prior 5 lines for
+    # `[ ! -L`.
+    #
+    # We use a python helper because bash + multi-line + alternation is
+    # painful. The script is well under 4000 lines so the perf cost is
+    # trivial.
+    python3 - "$SCRIPT_PATH" <<'PY'
+import re
+import sys
+
+script_path = sys.argv[1]
+with open(script_path) as f:
+    lines = f.readlines()
+
+# Find every line that contains `find ... -delete` and isn't inside the
+# `safe_clear_directory` helper body (which is allowed to have multiple
+# forms by design).
+violations = []
+in_safe_clear = False
+brace_depth = 0
+for i, line in enumerate(lines):
+    n = i + 1
+
+    # Track whether we're inside safe_clear_directory's function body.
+    # The function definition starts with `safe_clear_directory() {` and
+    # ends at the matching closing `}`.
+    if re.search(r'^safe_clear_directory\s*\(\s*\)\s*\{', line):
+        in_safe_clear = True
+        brace_depth = 1
+        continue
+    if in_safe_clear:
+        brace_depth += line.count('{') - line.count('}')
+        if brace_depth <= 0:
+            in_safe_clear = False
+        continue
+
+    # Look for `find ... -delete` on this line.
+    if not re.search(r'\bfind\b.+\-delete\b', line):
+        continue
+
+    # Skip comment lines. `find -delete` mentioned in a comment is
+    # documentation, not a real call.
+    stripped = line.lstrip()
+    if stripped.startswith('#'):
+        continue
+
+    # Same-line type filter is enough.
+    if re.search(r'-(?:type\s+[fd]|type\s+[fd]\b)', line):
+        continue
+    if '-type f' in line or '-type d' in line:
+        continue
+
+    # Otherwise, look at the 5 preceding lines for a `[ ! -L "$X" ]`
+    # parent guard. The guard is a common idiom and may span an `if`
+    # statement boundary.
+    context = ''.join(lines[max(0, i-5):i+1])
+    if re.search(r'\[\s*!\s*-L\s+"\$', context):
+        continue
+
+    # System-path finds (no `$VAR` interpolation) are out of scope for
+    # this test — the system owns /private/var/tmp and /private/tmp.
+    if '/private/var/tmp' in line or '/private/tmp' in line:
+        continue
+
+    violations.append((n, line.rstrip()))
+
+if violations:
+    print('find -delete lines without type filter or [ ! -L ] guard:', file=sys.stderr)
+    for n, line in violations:
+        print(f'  {n}: {line}', file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+test_user_home_derivation_uses_sudo_user() {
+    # The script's USER_HOME derivation must (a) use $SUDO_USER's passwd
+    # entry under sudo (via getent), and (b) fall back to $HOME when
+    # SUDO_USER is unset. We verify both by reading the relevant
+    # source block from the script.
+    #
+    # Specifically, the block at "Get and validate actual user" must
+    # contain:
+    #   1. `if [ -n "${SUDO_USER:-}" ]` (or equivalent) to detect sudo
+    #   2. `getent passwd "$SUDO_USER"` (or passwd lookup) to find the
+    #      home dir, since $HOME is unreliable under sudo
+    #   3. A fallback to `USER_HOME="$HOME"` when SUDO_USER is empty
+    #
+    # The audit caught a real bug where the script used $HOME for
+    # CONFIG_FILES / LOCKDIR / check_icloud_backup_enabled, missing
+    # the user's actual home under sudo. This test makes the derivation
+    # pattern the canonical place to look.
+    local block
+    block=$(/usr/bin/awk '/^# Get and validate actual user/,/^fi$/' "$SCRIPT_PATH")
+
+    if ! echo "$block" | /usr/bin/grep -qF 'SUDO_USER'; then
+        echo "USER_HOME derivation does not check SUDO_USER:" >&2
+        echo "$block" >&2
+        return 1
+    fi
+    if ! echo "$block" | /usr/bin/grep -qE 'getent passwd|/Users/\$SUDO_USER'; then
+        echo "USER_HOME derivation does not look up SUDO_USER's home via getent or /Users fallback:" >&2
+        echo "$block" >&2
+        return 1
+    fi
+    if ! echo "$block" | /usr/bin/grep -qF 'USER_HOME="$HOME"'; then
+        echo "USER_HOME derivation does not fall back to \$HOME when SUDO_USER is empty:" >&2
+        echo "$block" >&2
+        return 1
+    fi
+    return 0
+}
+
 # --- Run -------------------------------------------------------------------
 
 echo "Running smoke tests for clean-mac-space.sh helpers..."
@@ -196,6 +349,9 @@ assert "registry_get_display returns middle field"             test_registry_get
 assert "_init_skip_defaults sets every SKIP_X to false"        test_init_skip_defaults_sets_every_skip_to_false
 assert "CATEGORY_REGISTRY has 33 entries (1-28 + 3a/3b + 29/30/31)"  test_registry_has_33_entries
 assert "CATEGORY_REGISTRY has new SKIP_BROWSER_TOOLS/CRASH_REPORTS/USER_TOOL_CACHES" test_registry_has_new_categories
+assert "No literal '\$HOME/' in user paths (security audit)"            test_no_literal_home_in_user_paths
+assert "Every 'find ... -delete' has -type filter or [ ! -L ] guard"    test_find_delete_has_type_or_symlink_guard
+assert "USER_HOME derivation uses SUDO_USER with getent fallback"        test_user_home_derivation_uses_sudo_user
 
 TOTAL=$(( PASS + FAIL ))
 echo ""

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -310,6 +310,32 @@ if violations:
 PY
 }
 
+test_config_files_defined_before_load_config_file_call() {
+    # CONFIG_FILES array must be defined (i.e. the `CONFIG_FILES=(`
+    # line appears) BEFORE the `load_config_file` call site. The
+    # audit (PR #85) moved CONFIG_FILES to after USER_HOME derivation
+    # so it could use $USER_HOME, but accidentally left the call at
+    # its old position at the top of the script — the result was a
+    # for-loop in load_config_file iterating an empty array, silently
+    # loading no config. This test enforces the ordering.
+    local config_files_line load_call_line
+    config_files_line=$(/usr/bin/grep -nE '^CONFIG_FILES=\(' "$SCRIPT_PATH" | /usr/bin/head -1 | /usr/bin/cut -d: -f1 || echo 0)
+    load_call_line=$(/usr/bin/grep -nE '^\s*load_config_file\s*$' "$SCRIPT_PATH" | /usr/bin/head -1 | /usr/bin/cut -d: -f1 || echo 0)
+    if [ -z "$config_files_line" ] || [ "$config_files_line" = "0" ]; then
+        echo "No CONFIG_FILES=( assignment found in script" >&2
+        return 1
+    fi
+    if [ -z "$load_call_line" ] || [ "$load_call_line" = "0" ]; then
+        echo "No load_config_file call site found in script" >&2
+        return 1
+    fi
+    if [ "$config_files_line" -ge "$load_call_line" ]; then
+        echo "CONFIG_FILES is at line $config_files_line but load_config_file is called at line $load_call_line" >&2
+        echo "CONFIG_FILES must be defined before load_config_file is called" >&2
+        return 1
+    fi
+    return 0
+}
 test_user_home_derivation_uses_sudo_user() {
     # The script's USER_HOME derivation must (a) use $SUDO_USER's passwd
     # entry under sudo (via getent), and (b) fall back to $HOME when
@@ -368,6 +394,7 @@ assert "CATEGORY_REGISTRY has new SKIP_BROWSER_TOOLS/CRASH_REPORTS/USER_TOOL_CAC
 assert "No literal '\$HOME/' in user paths (security audit)"            test_no_literal_home_in_user_paths
 assert "Every 'find ... -delete' has -type filter or [ ! -L ] guard"    test_find_delete_has_type_or_symlink_guard
 assert "USER_HOME derivation uses SUDO_USER with getent fallback"        test_user_home_derivation_uses_sudo_user
+assert "CONFIG_FILES=() defined before load_config_file is called"      test_config_files_defined_before_load_config_file_call
 
 TOTAL=$(( PASS + FAIL ))
 echo ""


### PR DESCRIPTION
## What

Script-wide security audit. Three passes:

1. **$USER_HOME vs $HOME audit** — found 3 real bugs in infrastructure code that used literal $HOME at script-load time, before USER_HOME was derived. Under `sudo Mac-Clean` on default macOS sudoers (env_reset), $HOME resolves to /var/root, so all three silently missed the user's actual home.
2. **find -delete symlink-safety audit** — walked all 13 find -delete call sites. No bugs: every one has either a -type f/-type d filter (which inherently excludes symlinks) or a [ ! -L ] parent guard. Inconsistency noted, pattern documented.
3. **Sudo path-resolution audit** — the USER_HOME derivation logic (SUDO_USER + getent with $HOME fallback) is correct. No bugs.

The audit rules are codified as 3 new smoke tests in tests/run-tests.sh so future regressions get caught at CI time.

## The 3 bugs

| # | Where | What went wrong | Impact |
|---|---|---|---|
| 1 | CONFIG_FILES array (line 228) | Used $HOME/.maccleans.conf at script-load | Config file silently missed under sudo. The script loaded no config and the user got no warning. |
| 2 | LOCKDIR=$HOME/.macclean/lock (line 613) | Lock went to /var/root/.macclean/lock under sudo | A non-sudo Mac-Clean invocation would create a separate lock in the user's real home, defeating the concurrency check entirely. |
| 3 | check_icloud_backup_enabled (line 810, 812) | Used $HOME/Library/Logs/MobileBackup/Backup.log | The iOS-backup safety check (the function that warns before deleting category #21 backups) silently missed the user's real backup log. |

All three fixed by moving the references to after USER_HOME derivation and/or substituting $USER_HOME directly. Verified with 17/17 tests passing.

## The 3 audit tests

- test_no_literal_home_in_user_paths — greps for '"$HOME/' in the script and fails on any hit
- test_find_delete_has_type_or_symlink_guard — python helper walks script, finds every find -delete that isn't a comment, and verifies the same line has a -type filter or the prior 5 lines have a [ ! -L ] parent guard
- test_user_home_derivation_uses_sudo_user — extracts the 'Get and validate actual user' block and verifies it references SUDO_USER, uses getent (or the /Users/$SUDO_USER fallback), and has the USER_HOME=$HOME fallback for non-sudo invocations

The find -delete test is the most interesting — a small python helper (script is under 4000 lines so perf is fine) that excludes safe_clear_directory (allowed to have multiple safe forms by design) and system-path finds (/private/var/tmp, /private/tmp).

If a future PR adds a find -delete without one of those guards, CI fails. The cost is a ~3-second test run.

## Self-review

- [x] 17/17 smoke tests pass (was 14/14)
- [x] shellcheck -S warning clean on clean-mac-space.sh and tests/run-tests.sh
- [x] bash -n clean
- [x] All 3 bugs verified fixed: LOCKDIR reassignment + symlink-safe default, CONFIG_FILES uses $USER_HOME, check_icloud_backup_enabled uses $USER_HOME
- [x] Documentation updated in docs/explanation/security-model.md so the next contributor sees the rules without re-deriving them

## No release needed

chore: + fix: (not feat:), no new user-facing behavior beyond the bug fixes. The 3 fixes are in the safety/infrastructure path — they make existing correct behavior work correctly under sudo, they don't add new behavior. Per the new release-process doc, no version bump is needed after merge.

## Stats

```
 CHANGELOG.md                       |  15 ++++
 clean-mac-space.sh                 |  52 ++++++++++---
 docs/explanation/security-model.md |  11 +++
 tests/run-tests.sh                 | 156 +++++++++++++++++++++++++++++++++++++
 4 files changed, 224 insertions(+), 10 deletions(-)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Completed security audit addressing user home path handling under sudo.

* **Bug Fixes**
  * Corrected user directory detection to work properly when executed with elevated privileges.
  * Fixed iOS backup verification under sudo.

* **Documentation**
  * Added security model documentation explaining user-path and symlink-safety conventions.

* **Tests**
  * Added security-focused test coverage validating user home derivation and safe path practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->