### PR TITLE
fix: load_config_file honors the 3 v5.6.0 SKIP_X keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to MacCleans.sh are documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **`load_config_file` now honors the 3 v5.6.0 SKIP_X keys** (`SKIP_BROWSER_TOOLS`, `SKIP_CRASH_REPORTS`, `SKIP_USER_TOOL_CACHES`) — PR #84 (v5.6.0) added 3 new categories and updated CATEGORY_REGISTRY, the section bodies, the `--skip-X` CLI flags, and (per PR #86) the bash/zsh/fish completions, but missed the case statement in `load_config_file` and `maccleans.conf.example`. As a result, users who set `SKIP_BROWSER_TOOLS=true` (or the other two) in `~/.maccleans.conf` got a `WARNING: Unknown config key` at startup, the variable stayed at its default `false`, and the category was cleaned anyway — silently ignoring the user's intent. Caught by the v5.7.0 UX review. New regression test `test_config_loader_covers_every_registry_skip_x` enforces that every future SKIP_X in CATEGORY_REGISTRY has a corresponding case arm.
+
 ## [5.7.0] - 2026-06-05
 
 ### Added

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -409,6 +409,9 @@ load_config_file() {
                     SKIP_BUN) SKIP_BUN="$value" ;;
                     SKIP_PNPM) SKIP_PNPM="$value" ;;
                     SKIP_SYSTEM_TMP) SKIP_SYSTEM_TMP="$value" ;;
+                    SKIP_BROWSER_TOOLS) SKIP_BROWSER_TOOLS="$value" ;;
+                    SKIP_CRASH_REPORTS) SKIP_CRASH_REPORTS="$value" ;;
+                    SKIP_USER_TOOL_CACHES) SKIP_USER_TOOL_CACHES="$value" ;;
                     FORCE_XCODE) FORCE_XCODE="$value" ;;
                     FORCE_TRASH) FORCE_TRASH="$value" ;;
                     FORCE_ICLOUD_DRIVE) FORCE_ICLOUD_DRIVE="$value" ;;

--- a/maccleans.conf.example
+++ b/maccleans.conf.example
@@ -85,3 +85,6 @@ SKIP_DSSTORE=false            # Stray .DS_Store files on the home volume
 
 # System /tmp (default ON for safety; opt in with --clean-system-tmp on the CLI)
 SKIP_SYSTEM_TMP=true          # /tmp, /var/tmp, /private/var/folders/.../T/
+SKIP_BROWSER_TOOLS=false      # ~/.cache/puppeteer, ~/.cache/selenium (browser test binaries)
+SKIP_CRASH_REPORTS=false       # ~/Library/Logs/CrashReporter, ~/Library/Application Support/CrashReporter (7-day age threshold)
+SKIP_USER_TOOL_CACHES=false    # ~/.cache/{uv, giget, opencode, powershell, gh, starship, ...}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -443,8 +443,23 @@ test_config_loader_covers_every_registry_skip_x() {
     # registry, the --skip-X flags, the section bodies, and the
     # completions, but missed the load_config_file case statement AND
     # maccleans.conf.example. Caught by the v5.7.0 UX review.
+    #
+    # Constrain the extraction to the CATEGORY_REGISTRY=() block (between
+    # the assignment opener and the closing paren). If the registry ever
+    # moves, refactor the extractor first; this test should fail loud
+    # rather than silently miss vars.
+    local registry_block
+    registry_block=$(/usr/bin/awk '
+        /^CATEGORY_REGISTRY=\(/   { in_block=1; next }
+        in_block && /^\)/         { in_block=0 }
+        in_block                  { print }
+    ' "$SCRIPT_PATH")
+    if [ -z "$registry_block" ]; then
+        echo "CATEGORY_REGISTRY=() block not found in $SCRIPT_PATH — test misconfigured" >&2
+        return 1
+    fi
     local registry_skip
-    registry_skip=$(/usr/bin/grep -oE '"[0-9a-z]+\|[^|]+\|SKIP_[A-Z_]+"' "$SCRIPT_PATH" | /usr/bin/sed -E 's/.*\|(SKIP_[A-Z_]+)"/\1/' | /usr/bin/sort -u)
+    registry_skip=$(printf '%s\n' "$registry_block" | /usr/bin/grep -oE '\|SKIP_[A-Z_]+' | /usr/bin/sed -E 's/^\|//' | /usr/bin/sort -u)
     if [ -z "$registry_skip" ]; then
         echo "No SKIP_X vars found in CATEGORY_REGISTRY — test misconfigured" >&2
         return 1
@@ -452,13 +467,11 @@ test_config_loader_covers_every_registry_skip_x() {
     local missing=()
     local var
     while IFS= read -r var; do
-        if ! /usr/bin/grep -qF "${var})" "$SCRIPT_PATH"; then
-            # Use a precise check: a case arm in load_config_file. The
-            # pattern `${var}) SKIP_X=` (or similar) appears in the case
-            # statement. We also accept the FORCE_*/VERBOSE/etc. form.
-            if ! /usr/bin/grep -qE "^\s*${var}\)" "$SCRIPT_PATH"; then
-                missing+=("$var")
-            fi
+        # Anchored match: a case arm starts with optional leading whitespace
+        # then the var name followed by ')'. The FORCE_*/VERBOSE/etc. arms
+        # are non-SKIP keys and are not checked here — only SKIP_X.
+        if ! /usr/bin/grep -qE "^[[:space:]]+${var}\)" "$SCRIPT_PATH"; then
+            missing+=("$var")
         fi
     done <<< "$registry_skip"
     if [ "${#missing[@]}" -gt 0 ]; then

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -431,6 +431,44 @@ test_completions_include_v56_skip_flags() {
     done
     return 0
 }
+test_config_loader_covers_every_registry_skip_x() {
+    # load_config_file's case statement must have a SKIP_X arm for every
+    # SKIP_X var declared in CATEGORY_REGISTRY. Otherwise a user's
+    # `SKIP_NEW_CATEGORY=true` in ~/.maccleans.conf silently falls through
+    # to the "Unknown config key" warning, the var stays at its default
+    # `false`, and the category gets cleaned anyway.
+    #
+    # v5.6.0 (PR #84) added 3 categories — SKIP_BROWSER_TOOLS,
+    # SKIP_CRASH_REPORTS, SKIP_USER_TOOL_CACHES — and updated the
+    # registry, the --skip-X flags, the section bodies, and the
+    # completions, but missed the load_config_file case statement AND
+    # maccleans.conf.example. Caught by the v5.7.0 UX review.
+    local registry_skip
+    registry_skip=$(/usr/bin/grep -oE '"[0-9a-z]+\|[^|]+\|SKIP_[A-Z_]+"' "$SCRIPT_PATH" | /usr/bin/sed -E 's/.*\|(SKIP_[A-Z_]+)"/\1/' | /usr/bin/sort -u)
+    if [ -z "$registry_skip" ]; then
+        echo "No SKIP_X vars found in CATEGORY_REGISTRY — test misconfigured" >&2
+        return 1
+    fi
+    local missing=()
+    local var
+    while IFS= read -r var; do
+        if ! /usr/bin/grep -qF "${var})" "$SCRIPT_PATH"; then
+            # Use a precise check: a case arm in load_config_file. The
+            # pattern `${var}) SKIP_X=` (or similar) appears in the case
+            # statement. We also accept the FORCE_*/VERBOSE/etc. form.
+            if ! /usr/bin/grep -qE "^\s*${var}\)" "$SCRIPT_PATH"; then
+                missing+=("$var")
+            fi
+        fi
+    done <<< "$registry_skip"
+    if [ "${#missing[@]}" -gt 0 ]; then
+        echo "load_config_file case statement is missing arms for: ${missing[*]}" >&2
+        echo "Every SKIP_X var declared in CATEGORY_REGISTRY must have a case arm" >&2
+        echo "in load_config_file (otherwise config-file settings are silently ignored)." >&2
+        return 1
+    fi
+    return 0
+}
 test_config_files_defined_before_load_config_file_call() {
     # The audit (PR #85) moved CONFIG_FILES to after USER_HOME derivation
     # so it could use $USER_HOME, but accidentally left the call at
@@ -519,6 +557,7 @@ assert '--json output block includes the "details" object'              test_jso
 assert "scripts/release.sh supports --check mode"                       test_release_sh_check_mode
 assert ".github/workflows/release-check.yml exists"                      test_release_check_workflow_exists
 assert "Completions include the 3 v5.6.0 --skip-X flags"                 test_completions_include_v56_skip_flags
+assert "load_config_file case statement covers every registry SKIP_X"     test_config_loader_covers_every_registry_skip_x
 
 TOTAL=$(( PASS + FAIL ))
 echo ""


### PR DESCRIPTION
## Summary

The 3 SKIP_X vars added in PR #84 (v5.6.0) were not added to `load_config_file`'s case statement or to `maccleans.conf.example`. A user setting `SKIP_BROWSER_TOOLS=true` (or the other two) in their config file got a `WARNING: Unknown config key` warning, the variable stayed at its default `false`, and the category was cleaned anyway — **silently ignoring the user's intent**.

This is a real data-loss bug for any user who configured the new v5.6.0 categories in their config file. Caught by the v5.7.0 UX review (UX & output track of the codebase review plan).

## What changed

- `load_config_file`: 3 new case arms for `SKIP_BROWSER_TOOLS`, `SKIP_CRASH_REPORTS`, `SKIP_USER_TOOL_CACHES`
- `maccleans.conf.example`: 3 new documented keys with comments
- `tests/run-tests.sh`: new test `test_config_loader_covers_every_registry_skip_x` that enforces every future SKIP_X in CATEGORY_REGISTRY has a config-loader case arm (so this class of bug can't happen again)
- `CHANGELOG.md`: [Unreleased] entry under Bug Fixes

## Why this isn't a breaking change

Before this fix, the 3 SKIP_X keys in CATEGORY_REGISTRY were effectively dead code at the config-file level. After this fix, they work as documented and as users expect. CLI flags (`--skip-browser-tools` etc.) have always worked — this fix only restores the config-file path.

## Verification

- 24/24 smoke tests pass (was 23/23; new test added)
- `bash -n clean-mac-space.sh` clean
- `shellcheck -S warning` clean

## Suggested target release

v5.7.1 (patch). Per the new release-process doc, this is a `fix:` so it should ship as a patch release once you merge and the `release.sh --check` gate passes.

🤖 Generated with [Mavis](https://minimaxi.com)

## Summary by Sourcery

Ensure configuration-based skip flags for new cleanup categories are correctly honored and guarded by regression tests.

Bug Fixes:
- Make load_config_file recognize and honor SKIP_BROWSER_TOOLS, SKIP_CRASH_REPORTS, and SKIP_USER_TOOL_CACHES from the config file instead of treating them as unknown keys.

Documentation:
- Document the three new SKIP_X config keys in maccleans.conf.example.
- Record the config loader bug fix for the v5.6.0 SKIP_X keys in the Unreleased section of the changelog.

Tests:
- Add a regression test to verify every SKIP_X entry in CATEGORY_REGISTRY has a corresponding case arm in load_config_file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Configuration options for skipping browser tools, crash reports, and user tool caches now correctly parse from configuration files and function as intended, resolving previous warnings and unexpected behaviour.

* **Tests**
  * Added regression test to ensure all configuration skip options are properly supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->