### PR TITLE
feat: JetBrains IDE Caches category (#36)

### DIFF
--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -79,6 +79,7 @@ VERSION="5.8.0"
 #   --skip-crash-reports Skip crash reports cleanup (NEW)
 #   --skip-user-tool-caches Skip user tool caches in ~/.cache/ (NEW)
 #   --skip-jvm         Skip JVM build cache cleanup (Maven/Ivy/sbt) (NEW)
+#   --skip-jetbrains    Skip JetBrains IDE cache cleanup (NEW)
 #   --skip-system-tmp   Skip /tmp and /var/tmp cleanup (default: on, opt-in via --clean-system-tmp)
 #   --clean-system-tmp  Opt in to /tmp and /var/tmp cleanup (default off; overrides --skip-system-tmp)
 #   --photos-library    Specify Photos library name or "all" to clean all libraries
@@ -138,6 +139,7 @@ CATEGORY_REGISTRY=(
     "31|User Tool Caches|SKIP_USER_TOOL_CACHES"
     "34|Xcode Archives|SKIP_XCODE_ARCHIVES"
     "35|JVM Build Caches|SKIP_JVM"
+    "36|JetBrains IDE Caches|SKIP_JETBRAINS"
 )
 
 # Single-field accessors for CATEGORY_REGISTRY entries. Format is
@@ -414,6 +416,7 @@ load_config_file() {
                     SKIP_SYSTEM_TMP) SKIP_SYSTEM_TMP="$value" ;;
                     SKIP_BROWSER_TOOLS) SKIP_BROWSER_TOOLS="$value" ;;
                     SKIP_CRASH_REPORTS) SKIP_CRASH_REPORTS="$value" ;;
+                    SKIP_JETBRAINS) SKIP_JETBRAINS="$value" ;;
                     SKIP_USER_TOOL_CACHES) SKIP_USER_TOOL_CACHES="$value" ;;
                     SKIP_XCODE_ARCHIVES) SKIP_XCODE_ARCHIVES="$value" ;;
                     SKIP_JVM) SKIP_JVM="$value" ;;
@@ -3473,6 +3476,51 @@ if run_category "35|JVM Build Caches|SKIP_JVM"; then
         fi
     else
         log "No JVM build caches found"
+    fi
+    log_plain ""
+fi
+
+###############################################################################
+# 36. JetBrains IDE Caches
+###############################################################################
+if run_category "36|JetBrains IDE Caches|SKIP_JETBRAINS"; then
+
+    # Every JetBrains IDE (IntelliJ IDEA, PyCharm, WebStorm, GoLand,
+    # CLion, RubyMine, PhpStorm, Android Studio, ...) writes per-version
+    # cache directories under ~/Library/Caches/JetBrains. Old versions'
+    # caches are never cleaned up after an upgrade and routinely
+    # accumulate several GB. The caches (indexes, compiled output,
+    # local history metadata) rebuild automatically on the next IDE
+    # launch.
+    #
+    # STRICTLY OUT OF SCOPE — never touched by this category:
+    #   ~/Library/Application Support/JetBrains  (config + plugins;
+    #     deleting it loses IDE settings and installed plugins)
+    #   ~/Library/Logs/JetBrains                 (diagnostic logs)
+    #   ~/.vscode-style extension directories    (not JetBrains-owned)
+    # Only the Caches tree is cleared.
+    #
+    # Use $USER_HOME (not $HOME) so the user's home is targeted under
+    # sudo — same convention as every other category in the script.
+    JETBRAINS_CACHE_DIR="$USER_HOME/Library/Caches/JetBrains"
+
+    if measured=$(measure_cache_dir "$JETBRAINS_CACHE_DIR"); then
+        JETBRAINS_BYTES="${measured%%|*}"
+        JETBRAINS_HUMAN="${measured#*|}"
+        record_category_size "JetBrains IDE Caches" "$JETBRAINS_BYTES" "$JETBRAINS_HUMAN"
+        log "Found JetBrains IDE caches: $JETBRAINS_HUMAN"
+
+        if [ "$DRY_RUN" = true ]; then
+            log "Would clear JetBrains IDE caches: $JETBRAINS_HUMAN"
+            TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + JETBRAINS_BYTES))
+        else
+            log "Clearing JetBrains IDE caches..."
+            [ -d "$JETBRAINS_CACHE_DIR" ] && [ ! -L "$JETBRAINS_CACHE_DIR" ] && safe_clear_directory "$JETBRAINS_CACHE_DIR" 2>/dev/null || true
+            log_success "JetBrains IDE caches cleared: $JETBRAINS_HUMAN"
+            TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + JETBRAINS_BYTES))
+        fi
+    else
+        log "No JetBrains IDE caches found"
     fi
     log_plain ""
 fi

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -3489,9 +3489,13 @@ if run_category "36|JetBrains IDE Caches|SKIP_JETBRAINS"; then
     # CLion, RubyMine, PhpStorm, Android Studio, ...) writes per-version
     # cache directories under ~/Library/Caches/JetBrains. Old versions'
     # caches are never cleaned up after an upgrade and routinely
-    # accumulate several GB. The caches (indexes, compiled output,
-    # local history metadata) rebuild automatically on the next IDE
-    # launch.
+    # accumulate several GB. The caches (indexes, compiled output)
+    # rebuild automatically on the next IDE launch.
+    #
+    # WARNING: IDE Local History lives INSIDE this tree
+    # (<product><version>/LocalHistory) and is PERMANENTLY LOST when
+    # the cache tree is deleted — it does NOT rebuild. Settings and
+    # plugins in Application Support are unaffected.
     #
     # STRICTLY OUT OF SCOPE — never touched by this category:
     #   ~/Library/Application Support/JetBrains  (config + plugins;

--- a/completions/_mac-cleans
+++ b/completions/_mac-cleans
@@ -52,6 +52,7 @@ _mac_cleans() {
         '--skip-crash-reports[Skip crash reports cleanup]'
         '--skip-user-tool-caches[Skip user tool caches in ~/.cache/]'
         '--skip-jvm[Skip JVM build caches (Maven/Ivy/sbt)]'
+        '--skip-jetbrains[Skip JetBrains IDE caches (IntelliJ, PyCharm, ...)]'
         '--skip-system-tmp[Skip /tmp and /var/tmp (default: on)]'
         '--clean-system-tmp[Opt in to /tmp and /var/tmp cleanup]'
     )

--- a/completions/mac-cleans.bash
+++ b/completions/mac-cleans.bash
@@ -18,6 +18,7 @@ _mac_cleans() {
         --skip-ios-backups --skip-ios-updates --skip-cocoapods
         --skip-gradle --skip-go --skip-bun --skip-pnpm
         --skip-browser-tools --skip-crash-reports --skip-user-tool-caches --skip-jvm
+        --skip-jetbrains
         --skip-system-tmp --clean-system-tmp
     )
 

--- a/completions/mac-cleans.fish
+++ b/completions/mac-cleans.fish
@@ -48,6 +48,7 @@ complete -c mac-cleans -l skip-browser-tools -d 'Skip browser testing tool cache
 complete -c mac-cleans -l skip-crash-reports -d 'Skip crash reports cleanup'
 complete -c mac-cleans -l skip-user-tool-caches -d 'Skip user tool caches in ~/.cache/'
 complete -c mac-cleans -l skip-jvm -d 'Skip JVM build caches (Maven/Ivy/sbt)'
+complete -c mac-cleans -l skip-jetbrains -d 'Skip JetBrains IDE caches (IntelliJ, PyCharm, ...)'
 complete -c mac-cleans -l skip-system-tmp -d 'Skip /tmp and /var/tmp (default: on)'
 complete -c mac-cleans -l clean-system-tmp -d 'Opt in to /tmp and /var/tmp cleanup'
 

--- a/docs/reference/categories.md
+++ b/docs/reference/categories.md
@@ -582,11 +582,13 @@ sudo Mac-Clean --dry-run --skip-homebrew --skip-npm --skip-pip --skip-jvm
 
 **Typical Size:** 1-10GB (High — per-version cache directories accumulate across IDE upgrades and are never cleaned up automatically)
 
-**What it does:** Every JetBrains IDE (IntelliJ IDEA, PyCharm, WebStorm, GoLand, CLion, RubyMine, PhpStorm, Android Studio, ...) writes per-version cache directories under `~/Library/Caches/JetBrains`. Old versions' caches survive upgrades indefinitely. MacCleans clears the whole Caches tree; the next IDE launch rebuilds whatever indexes it needs.
+**What it does:** Every JetBrains IDE (IntelliJ IDEA, PyCharm, WebStorm, GoLand, CLion, RubyMine, PhpStorm, Android Studio, ...) writes per-version cache directories under `~/Library/Caches/JetBrains`. Old versions' caches survive upgrades indefinitely. MacCleans clears the whole Caches tree; the caches themselves (indexes, compiled output) rebuild on the next IDE launch.
 
 **Note:** Strictly out of scope: `~/Library/Application Support/JetBrains` (IDE settings + installed plugins — deleting it loses your configuration), `~/Library/Logs/JetBrains`, and VS Code-style extension directories. Only the Caches tree is touched.
 
-**Risk:** High - the caches themselves rebuild safely on the next launch, but a first launch after clearing re-indexes every open project (5-30 minutes of CPU per project). Skip this category if you cannot afford the re-index time.
+**Warning:** IDE Local History lives inside the Caches tree (`<product><version>/LocalHistory`) and is **permanently lost** when it is deleted — it does not rebuild. Your settings and plugins under `~/Library/Application Support/JetBrains` are unaffected.
+
+**Risk:** High - the caches themselves rebuild on the next launch, but a first launch after clearing re-indexes every open project (5-30 minutes of CPU per project). Skip this category if you cannot afford the re-index time.
 
 ```bash
 # Skip JetBrains IDE caches

--- a/docs/reference/categories.md
+++ b/docs/reference/categories.md
@@ -37,6 +37,7 @@ Complete reference of all cleanup categories in MacCleans.
 | Crash Reports | 100MB-1GB | Low | `--skip-crash-reports` |
 | User Tool Caches | 500MB-2GB | Low | `--skip-user-tool-caches` |
 | JVM Build Caches | 500MB-5GB | Medium | `--skip-jvm` |
+| JetBrains IDE Caches | 1-10GB | High | `--skip-jetbrains` |
 | System Cache | 100MB-1GB | Low | (always safe) |
 | User Cache | 100MB-1GB | Low | (always safe) |
 
@@ -571,6 +572,25 @@ sudo Mac-Clean --yes --skip-user-tool-caches
 ```bash
 # Skip JVM build caches
 sudo Mac-Clean --dry-run --skip-homebrew --skip-npm --skip-pip --skip-jvm
+```
+
+---
+
+### JetBrains IDE Caches
+
+**Paths:** `~/Library/Caches/JetBrains` (entire tree)
+
+**Typical Size:** 1-10GB (High — per-version cache directories accumulate across IDE upgrades and are never cleaned up automatically)
+
+**What it does:** Every JetBrains IDE (IntelliJ IDEA, PyCharm, WebStorm, GoLand, CLion, RubyMine, PhpStorm, Android Studio, ...) writes per-version cache directories under `~/Library/Caches/JetBrains`. Old versions' caches survive upgrades indefinitely. MacCleans clears the whole Caches tree; the next IDE launch rebuilds whatever indexes it needs.
+
+**Note:** Strictly out of scope: `~/Library/Application Support/JetBrains` (IDE settings + installed plugins — deleting it loses your configuration), `~/Library/Logs/JetBrains`, and VS Code-style extension directories. Only the Caches tree is touched.
+
+**Risk:** High - the caches themselves rebuild safely on the next launch, but a first launch after clearing re-indexes every open project (5-30 minutes of CPU per project). Skip this category if you cannot afford the re-index time.
+
+```bash
+# Skip JetBrains IDE caches
+sudo Mac-Clean --yes --skip-jetbrains
 ```
 
 ---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -267,6 +267,7 @@ sudo Mac-Clean --yes \
   --skip-crash-reports \
   --skip-user-tool-caches \
   --skip-jvm \
+  --skip-jetbrains \
   --skip-system-tmp \
   --clean-system-tmp
 ```

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -53,6 +53,7 @@ CLI flags override config values. See [how-to/configure.md](../how-to/configure.
 | `SKIP_PNPM` | `false` | Skip pnpm store. |
 | `SKIP_JVM` | `false` | Skip Maven / Ivy / sbt build caches. |
 | `SKIP_SYSTEM_TMP` | `true` | Skip `/tmp` and `/var/tmp`. **Default-on** for safety; opt in with `--clean-system-tmp` or set `SKIP_SYSTEM_TMP=false`. |
+| `SKIP_JETBRAINS` | `false` | Skip JetBrains IDE caches (`~/Library/Caches/JetBrains`). Settings/plugins in Application Support are never touched. |
 
 ## String values
 

--- a/maccleans.conf.example
+++ b/maccleans.conf.example
@@ -90,3 +90,4 @@ SKIP_CRASH_REPORTS=false       # ~/Library/Logs/CrashReporter, ~/Library/Applica
 SKIP_XCODE_ARCHIVES=false      # ~/Library/Developer/Xcode/Archives (release builds + dSYMs; --force-xcode required on CLI)
 SKIP_USER_TOOL_CACHES=false    # ~/.cache/{uv, giget, opencode, powershell, gh, starship, ...}
 SKIP_JVM=false                 # ~/.m2/repository, ~/.ivy2/cache, ~/.sbt/boot (re-downloaded on next build)
+SKIP_JETBRAINS=false         # ~/Library/Caches/JetBrains (per-version IDE caches; rebuild on next launch)

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -195,6 +195,25 @@ test_registry_has_jvm_build_caches() {
     [ "$found_jvm" -eq 1 ]
 }
 
+test_registry_has_jetbrains_ide_caches() {
+    # Verify the v6 #36 entry exists with the right display name and
+    # skip_var wiring. Walks CATEGORY_REGISTRY like
+    # test_registry_has_new_categories does, so it survives renumbering.
+    local entry found_jb display
+    found_jb=0
+    for entry in "${CATEGORY_REGISTRY[@]}"; do
+        if [ "$(registry_get_skip_var "$entry")" = "SKIP_JETBRAINS" ]; then
+            found_jb=1
+            display=$(registry_get_display "$entry")
+            [ "$display" = "JetBrains IDE Caches" ] || {
+                echo "SKIP_JETBRAINS entry has display '$display', expected 'JetBrains IDE Caches'" >&2
+                return 1
+            }
+        fi
+    done
+    [ "$found_jb" -eq 1 ]
+}
+
 # --- Security audit tests (added 2026-06-05) -------------------------------
 #
 # These tests codify the three rules from the security audit pass:
@@ -420,6 +439,25 @@ test_release_check_workflow_exists() {
     return 0
 }
 
+
+test_completions_include_jetbrains_skip_flag() {
+    # v6 added --skip-jetbrains for the new #36 category. Mirrors
+    # test_completions_include_xcode_archives_skip_flag: bash and zsh
+    # use the literal --skip-foo token; fish uses `-l skip-foo`.
+    if ! /usr/bin/grep -qF -e "--skip-jetbrains" "$REPO_ROOT/completions/mac-cleans.bash"; then
+        echo "completions/mac-cleans.bash missing --skip-jetbrains" >&2
+        return 1
+    fi
+    if ! /usr/bin/grep -qF -e "--skip-jetbrains" "$REPO_ROOT/completions/_mac-cleans"; then
+        echo "completions/_mac-cleans missing --skip-jetbrains" >&2
+        return 1
+    fi
+    if ! /usr/bin/grep -qF -e "-l skip-jetbrains" "$REPO_ROOT/completions/mac-cleans.fish"; then
+        echo "completions/mac-cleans.fish missing -l skip-jetbrains" >&2
+        return 1
+    fi
+    return 0
+}
 test_completions_include_xcode_archives_skip_flag() {
     # v5.8.0 added --skip-xcode-archives for the new #34 category.
     # Without this test, a future refactor of the completion files
@@ -656,6 +694,8 @@ assert "Completions include the v5.8.0 --skip-xcode-archives flag"         test_
 assert "Completions include the v6 --skip-jvm flag"                        test_completions_include_jvm_skip_flag
 assert "load_config_file case statement covers every registry SKIP_X"     test_config_loader_covers_every_registry_skip_x
 assert "Interactive menu digit handler covers 1-N (no silent swallow)"    test_interactive_menu_handles_all_digit_ranges
+assert "CATEGORY_REGISTRY has the #36 JetBrains IDE Caches entry"        test_registry_has_jetbrains_ide_caches
+assert "Completions include the v6 --skip-jetbrains flag"                test_completions_include_jetbrains_skip_flag
 
 TOTAL=$(( PASS + FAIL ))
 echo ""


### PR DESCRIPTION
## What

New cleanup category **#36 JetBrains IDE Caches** (`SKIP_JETBRAINS`, `--skip-jetbrains`): cleans the entire `~/Library/Caches/JetBrains` tree, where per-version IDE cache dirs accumulate across upgrades (often 1-10GB).

## Safety story — read this one

IDE caches rebuild automatically on next launch. **However**: JetBrains Local History lives *inside* this tree (`<product><version>/LocalHistory`) and is **permanently lost** on deletion — this is now explicitly documented in both the script comment and docs (fixed after review caught the original "rebuilds safely" claim). Settings and plugins live in `~/Library/Application Support/JetBrains`, which is strictly out of scope, as are Logs.

## Wiring (full registry contract)

- Registry entry, help line, config-loader case, conf.example
- Completions x3; docs: categories.md row + section, config-file.md, commands.md flag list
- Tests: registry-walk presence + completion parity (28/28 pass)

## Verification

- `bash -n`, `shellcheck -S warning` clean; 28/28 tests
- Behavioral review: symlinked cache root refused with target byte-identical; dry-run parity; JSON details fragment valid

## Review gate

Scored **100/100** by two independent reviewer agents after a fix-up round correcting the Local History data-loss documentation (the round-1 major finding) and adding the flag to commands.md.

Merge order: depends on #90 (test-infra).

🧹 Clean code, clean disk

## Summary by Sourcery

Add an opt-out JetBrains IDE cache cleanup category with complete CLI, configuration, documentation, completion, and test integration.

New Features:
- Add JetBrains IDE cache cleanup for the ~/Library/Caches/JetBrains tree, including the --skip-jetbrains option and configuration support.

Enhancements:
- Document the category’s high-risk behavior, including permanent deletion of JetBrains Local History while leaving settings, plugins, and logs untouched.

Documentation:
- Add JetBrains cache category details, command-line usage, configuration reference, and shell completion support to the documentation.

Tests:
- Add coverage verifying registry integration and parity of the --skip-jetbrains flag across shell completions.