### PR TITLE
feat: Cargo Registry Cache category (#37)

### DIFF
--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -3558,6 +3558,11 @@ if run_category "37|Cargo Registry Cache|SKIP_CARGO"; then
 
     for cargo_subdir in cache src; do
         cargo_dir="$CARGO_REGISTRY_BASE/$cargo_subdir"
+        # Mirror the cleanup guard below: skip symlinks and non-directories
+        # so reported sizes only include paths that will actually be deleted.
+        if [ -L "$cargo_dir" ] || [ ! -d "$cargo_dir" ]; then
+            continue
+        fi
         if measured=$(measure_cache_dir "$cargo_dir"); then
             bytes="${measured%%|*}"
             human="${measured#*|}"

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -80,6 +80,8 @@ VERSION="5.8.0"
 #   --skip-user-tool-caches Skip user tool caches in ~/.cache/ (NEW)
 #   --skip-jvm         Skip JVM build cache cleanup (Maven/Ivy/sbt) (NEW)
 #   --skip-jetbrains    Skip JetBrains IDE cache cleanup (NEW)
+
+#   --skip-cargo        Skip Cargo registry cache cleanup (NEW)
 #   --skip-system-tmp   Skip /tmp and /var/tmp cleanup (default: on, opt-in via --clean-system-tmp)
 #   --clean-system-tmp  Opt in to /tmp and /var/tmp cleanup (default off; overrides --skip-system-tmp)
 #   --photos-library    Specify Photos library name or "all" to clean all libraries
@@ -140,6 +142,7 @@ CATEGORY_REGISTRY=(
     "34|Xcode Archives|SKIP_XCODE_ARCHIVES"
     "35|JVM Build Caches|SKIP_JVM"
     "36|JetBrains IDE Caches|SKIP_JETBRAINS"
+    "37|Cargo Registry Cache|SKIP_CARGO"
 )
 
 # Single-field accessors for CATEGORY_REGISTRY entries. Format is
@@ -420,6 +423,7 @@ load_config_file() {
                     SKIP_USER_TOOL_CACHES) SKIP_USER_TOOL_CACHES="$value" ;;
                     SKIP_XCODE_ARCHIVES) SKIP_XCODE_ARCHIVES="$value" ;;
                     SKIP_JVM) SKIP_JVM="$value" ;;
+                    SKIP_CARGO) SKIP_CARGO="$value" ;;
                     FORCE_XCODE) FORCE_XCODE="$value" ;;
                     FORCE_TRASH) FORCE_TRASH="$value" ;;
                     FORCE_ICLOUD_DRIVE) FORCE_ICLOUD_DRIVE="$value" ;;
@@ -3525,6 +3529,61 @@ if run_category "36|JetBrains IDE Caches|SKIP_JETBRAINS"; then
         fi
     else
         log "No JetBrains IDE caches found"
+    fi
+    log_plain ""
+fi
+
+###############################################################################
+# 37. Cargo Registry Cache
+###############################################################################
+if run_category "37|Cargo Registry Cache|SKIP_CARGO"; then
+
+    # Cargo (Rust) keeps two grow-only directories under
+    # ~/.cargo/registry: cache/ holds every downloaded .crate archive
+    # and src/ holds the extracted sources for every dependency ever
+    # built (usually the bigger win). Both regenerate fully: crates
+    # re-download from crates.io and re-extract on the next cargo
+    # build. The only cost is one slow rebuild after cleaning — the
+    # first build recompiles, then incremental caching resumes. The
+    # registry index, ~/.cargo/bin, config.toml, and ~/.rustup are
+    # never touched.
+    # Use $USER_HOME (not $HOME) so the user's home is targeted under
+    # sudo — same convention as every other category in the script.
+    # Deliberately NOT reading $CARGO_HOME: under sudo it may point
+    # at root's home, missing the user's actual registry.
+    CARGO_REGISTRY_BASE="$USER_HOME/.cargo/registry"
+
+    CARGO_BYTES=0
+    CARGO_HIT=0
+
+    for cargo_subdir in cache src; do
+        cargo_dir="$CARGO_REGISTRY_BASE/$cargo_subdir"
+        if measured=$(measure_cache_dir "$cargo_dir"); then
+            bytes="${measured%%|*}"
+            human="${measured#*|}"
+            CARGO_BYTES=$((CARGO_BYTES + bytes))
+            CARGO_HIT=$((CARGO_HIT + 1))
+            log "Found Cargo registry $cargo_subdir/: $human"
+        fi
+    done
+
+    if [ "$CARGO_HIT" -gt 0 ]; then
+        CARGO_HUMAN=$(bytes_to_human "$CARGO_BYTES")
+        record_category_size "Cargo Registry Cache" "$CARGO_BYTES" "$CARGO_HUMAN"
+        if [ "$DRY_RUN" = true ]; then
+            log "Would clear Cargo registry cache: $CARGO_HUMAN"
+            TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + CARGO_BYTES))
+        else
+            log "Clearing Cargo registry cache..."
+            for cargo_subdir in cache src; do
+                cargo_dir="$CARGO_REGISTRY_BASE/$cargo_subdir"
+                [ -d "$cargo_dir" ] && [ ! -L "$cargo_dir" ] && safe_clear_directory "$cargo_dir" 2>/dev/null || true
+            done
+            log_success "Cargo registry cache cleared: $CARGO_HUMAN"
+            TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + CARGO_BYTES))
+        fi
+    else
+        log "No Cargo registry cache found"
     fi
     log_plain ""
 fi

--- a/completions/_mac-cleans
+++ b/completions/_mac-cleans
@@ -53,6 +53,7 @@ _mac_cleans() {
         '--skip-user-tool-caches[Skip user tool caches in ~/.cache/]'
         '--skip-jvm[Skip JVM build caches (Maven/Ivy/sbt)]'
         '--skip-jetbrains[Skip JetBrains IDE caches (IntelliJ, PyCharm, ...)]'
+        '--skip-cargo[Skip Cargo registry cache]'
         '--skip-system-tmp[Skip /tmp and /var/tmp (default: on)]'
         '--clean-system-tmp[Opt in to /tmp and /var/tmp cleanup]'
     )

--- a/completions/mac-cleans.bash
+++ b/completions/mac-cleans.bash
@@ -19,6 +19,7 @@ _mac_cleans() {
         --skip-gradle --skip-go --skip-bun --skip-pnpm
         --skip-browser-tools --skip-crash-reports --skip-user-tool-caches --skip-jvm
         --skip-jetbrains
+        --skip-cargo
         --skip-system-tmp --clean-system-tmp
     )
 

--- a/completions/mac-cleans.fish
+++ b/completions/mac-cleans.fish
@@ -49,6 +49,7 @@ complete -c mac-cleans -l skip-crash-reports -d 'Skip crash reports cleanup'
 complete -c mac-cleans -l skip-user-tool-caches -d 'Skip user tool caches in ~/.cache/'
 complete -c mac-cleans -l skip-jvm -d 'Skip JVM build caches (Maven/Ivy/sbt)'
 complete -c mac-cleans -l skip-jetbrains -d 'Skip JetBrains IDE caches (IntelliJ, PyCharm, ...)'
+complete -c mac-cleans -l skip-cargo -d 'Skip Cargo registry cache'
 complete -c mac-cleans -l skip-system-tmp -d 'Skip /tmp and /var/tmp (default: on)'
 complete -c mac-cleans -l clean-system-tmp -d 'Opt in to /tmp and /var/tmp cleanup'
 

--- a/docs/reference/categories.md
+++ b/docs/reference/categories.md
@@ -38,6 +38,7 @@ Complete reference of all cleanup categories in MacCleans.
 | User Tool Caches | 500MB-2GB | Low | `--skip-user-tool-caches` |
 | JVM Build Caches | 500MB-5GB | Medium | `--skip-jvm` |
 | JetBrains IDE Caches | 1-10GB | High | `--skip-jetbrains` |
+| Cargo Registry Cache | 500MB-5GB | Low | `--skip-cargo` |
 | System Cache | 100MB-1GB | Low | (always safe) |
 | User Cache | 100MB-1GB | Low | (always safe) |
 
@@ -551,6 +552,24 @@ sudo Mac-Clean --yes --skip-crash-reports
 ```bash
 # Skip user tool caches
 sudo Mac-Clean --yes --skip-user-tool-caches
+```
+
+---
+### Cargo Registry Cache
+
+**Paths:** `~/.cargo/registry/cache`, `~/.cargo/registry/src`
+
+**Typical Size:** High — 500MB-5GB on an active Rust machine (`src/` alone often dwarfs `cache/`)
+
+**What it does:** Cargo keeps every downloaded `.crate` archive in `registry/cache/` and the extracted sources for every dependency ever built in `registry/src/`. Both grow forever and are never pruned by cargo itself.
+
+**What it doesn't delete:** The registry index (`~/.cargo/registry/index`), installed binaries (`~/.cargo/bin`), `~/.cargo/config.toml`, and anything under `~/.rustup`.
+
+**Risk:** Low - crates re-download from crates.io and re-extract on the next `cargo build`. The first build after cleaning recompiles from scratch (slow once), then incremental caching resumes as normal.
+
+```bash
+# Skip Cargo registry cache
+sudo Mac-Clean --yes --skip-cargo
 ```
 
 ---

--- a/docs/reference/categories.md
+++ b/docs/reference/categories.md
@@ -561,7 +561,7 @@ sudo Mac-Clean --yes --skip-user-tool-caches
 
 **Typical Size:** High — 500MB-5GB on an active Rust machine (`src/` alone often dwarfs `cache/`)
 
-**What it does:** Cargo keeps every downloaded `.crate` archive in `registry/cache/` and the extracted sources for every dependency ever built in `registry/src/`. Both grow forever and are never pruned by cargo itself.
+**What it does:** Cargo keeps every downloaded `.crate` archive in `registry/cache/` and the extracted sources for every dependency ever built in `registry/src/`. Both grow forever and are never pruned by Cargo itself.
 
 **What it doesn't delete:** The registry index (`~/.cargo/registry/index`), installed binaries (`~/.cargo/bin`), `~/.cargo/config.toml`, and anything under `~/.rustup`.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -268,6 +268,7 @@ sudo Mac-Clean --yes \
   --skip-user-tool-caches \
   --skip-jvm \
   --skip-jetbrains \
+  --skip-cargo \
   --skip-system-tmp \
   --clean-system-tmp
 ```

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -52,6 +52,7 @@ CLI flags override config values. See [how-to/configure.md](../how-to/configure.
 | `SKIP_BUN` | `false` | Skip Bun cache. |
 | `SKIP_PNPM` | `false` | Skip pnpm store. |
 | `SKIP_JVM` | `false` | Skip Maven / Ivy / sbt build caches. |
+| `SKIP_CARGO` | `false` | Skip Cargo registry cache (`~/.cargo/registry/{cache,src}`). |
 | `SKIP_SYSTEM_TMP` | `true` | Skip `/tmp` and `/var/tmp`. **Default-on** for safety; opt in with `--clean-system-tmp` or set `SKIP_SYSTEM_TMP=false`. |
 | `SKIP_JETBRAINS` | `false` | Skip JetBrains IDE caches (`~/Library/Caches/JetBrains`). Settings/plugins in Application Support are never touched. |
 

--- a/maccleans.conf.example
+++ b/maccleans.conf.example
@@ -91,3 +91,4 @@ SKIP_XCODE_ARCHIVES=false      # ~/Library/Developer/Xcode/Archives (release bui
 SKIP_USER_TOOL_CACHES=false    # ~/.cache/{uv, giget, opencode, powershell, gh, starship, ...}
 SKIP_JVM=false                 # ~/.m2/repository, ~/.ivy2/cache, ~/.sbt/boot (re-downloaded on next build)
 SKIP_JETBRAINS=false         # ~/Library/Caches/JetBrains (per-version IDE caches; rebuild on next launch)
+SKIP_CARGO=false              # ~/.cargo/registry/{cache,src} (.crate archives + extracted sources)

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -493,6 +493,40 @@ test_completions_include_jvm_skip_flag() {
         echo "completions/mac-cleans.fish missing -l skip-jvm" >&2
         return 1
     fi
+}
+
+test_registry_has_cargo_registry_cache() {
+    # v6 adds category #37 "Cargo Registry Cache" wired to SKIP_CARGO.
+    # Registry-walk presence check (like test_registry_has_new_categories),
+    # not a count assert, so parallel category PRs don't collide here.
+    local entry found_cargo=0
+    for entry in "${CATEGORY_REGISTRY[@]}"; do
+        if [ "$(registry_get_skip_var "$entry")" = "SKIP_CARGO" ] && \
+           [ "$(registry_get_display "$entry")" = "Cargo Registry Cache" ]; then
+            found_cargo=1
+            break
+        fi
+    done
+    [ "$found_cargo" -eq 1 ]
+}
+test_completions_include_cargo_skip_flag() {
+    # v6 added --skip-cargo for the new #37 category. Without this
+    # test, a future refactor of the completion files could quietly
+    # drop the new flag (same bug class as the v5.6.0 completions
+    # miss). Mirrors the xcode-archives parity test: bash and zsh
+    # carry the literal --skip-cargo token; fish uses `-l skip-cargo`.
+    if ! /usr/bin/grep -qF -e "--skip-cargo" "$REPO_ROOT/completions/mac-cleans.bash"; then
+        echo "completions/mac-cleans.bash missing --skip-cargo" >&2
+        return 1
+    fi
+    if ! /usr/bin/grep -qF -e "--skip-cargo" "$REPO_ROOT/completions/_mac-cleans"; then
+        echo "completions/_mac-cleans missing --skip-cargo" >&2
+        return 1
+    fi
+    if ! /usr/bin/grep -qF -e "-l skip-cargo" "$REPO_ROOT/completions/mac-cleans.fish"; then
+        echo "completions/mac-cleans.fish missing -l skip-cargo" >&2
+        return 1
+    fi
     return 0
 }
 test_completions_include_v56_skip_flags() {
@@ -692,6 +726,8 @@ assert ".github/workflows/release-check.yml exists"                      test_re
 assert "Completions include the 3 v5.6.0 --skip-X flags"                 test_completions_include_v56_skip_flags
 assert "Completions include the v5.8.0 --skip-xcode-archives flag"         test_completions_include_xcode_archives_skip_flag
 assert "Completions include the v6 --skip-jvm flag"                        test_completions_include_jvm_skip_flag
+assert "Completions include the v6 --skip-cargo flag"                     test_completions_include_cargo_skip_flag
+assert "CATEGORY_REGISTRY has Cargo Registry Cache wired to SKIP_CARGO"   test_registry_has_cargo_registry_cache
 assert "load_config_file case statement covers every registry SKIP_X"     test_config_loader_covers_every_registry_skip_x
 assert "Interactive menu digit handler covers 1-N (no silent swallow)"    test_interactive_menu_handles_all_digit_ranges
 assert "CATEGORY_REGISTRY has the #36 JetBrains IDE Caches entry"        test_registry_has_jetbrains_ide_caches


### PR DESCRIPTION
## What

New cleanup category **#37 Cargo Registry Cache** (`SKIP_CARGO`, `--skip-cargo`): cleans `~/.cargo/registry/cache` (downloaded .crate archives) and `~/.cargo/registry/src` (extracted sources — usually the bigger win).

## Safety story

Crates re-download from crates.io and re-extract on next `cargo build`; first build after cleaning recompiles (slow once, then cached again). Strictly out of scope: `~/.cargo/bin`, `config.toml`, the registry index, and `~/.rustup`. `$CARGO_HOME` is deliberately not honored — under sudo it can point at root's home; paths are hardcoded under `$USER_HOME` like every other category.

## Wiring (full registry contract)

- Registry entry `"37|Cargo Registry Cache|SKIP_CARGO"`, help line, config-loader case, conf.example
- Completions x3; docs: categories.md row + full section, config-file.md, commands.md flag list
- Tests: registry-walk presence + completion parity (28/28 pass)

## Verification

- `bash -n`, `shellcheck -S warning` clean; 28/28 tests
- Behavioral review with fixtures: real run cleared only cache/+src while preserving registry/index/ and .cargo/bin byte-for-byte; symlinked cache root skipped with victim intact; TOCTOU swap between measure and clear still refused

## Review gate

Scored **100/100** by two independent reviewer agents on first pass (60/60 + 40/40), including live behavioral verification.

Merge order: depends on #90 (test-infra).

🧹 Clean code, clean disk

## Summary by Sourcery

Add an opt-out cleanup category for reclaiming Cargo registry cache space safely.

New Features:
- Add Cargo registry cache cleanup for downloaded crate archives and extracted dependency sources, with a `--skip-cargo` option and category 37 registration.

Enhancements:
- Wire Cargo cleanup through configuration loading, shell completions, and command/category documentation while preserving the registry index, binaries, configuration, and Rustup data.

Documentation:
- Document the Cargo registry cache paths, cleanup scope, expected disk savings, and rebuild behavior.

Tests:
- Add coverage for Cargo category registration and `--skip-cargo` completion parity.