### PR TITLE
feat: VS Code Cache category (#39)

### DIFF
--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -83,6 +83,7 @@ VERSION="5.8.0"
 
 #   --skip-cargo        Skip Cargo registry cache cleanup (NEW)
 #   --skip-nuget        Skip NuGet package cache cleanup (NEW)
+#   --skip-vscode       Skip VS Code cache cleanup (NEW)
 #   --skip-system-tmp   Skip /tmp and /var/tmp cleanup (default: on, opt-in via --clean-system-tmp)
 #   --clean-system-tmp  Opt in to /tmp and /var/tmp cleanup (default off; overrides --skip-system-tmp)
 #   --photos-library    Specify Photos library name or "all" to clean all libraries
@@ -145,6 +146,7 @@ CATEGORY_REGISTRY=(
     "36|JetBrains IDE Caches|SKIP_JETBRAINS"
     "37|Cargo Registry Cache|SKIP_CARGO"
     "38|NuGet Package Cache|SKIP_NUGET"
+    "39|VS Code Cache|SKIP_VSCODE"
 )
 
 # Single-field accessors for CATEGORY_REGISTRY entries. Format is
@@ -427,6 +429,7 @@ load_config_file() {
                     SKIP_JVM) SKIP_JVM="$value" ;;
                     SKIP_CARGO) SKIP_CARGO="$value" ;;
                     SKIP_NUGET) SKIP_NUGET="$value" ;;
+                    SKIP_VSCODE) SKIP_VSCODE="$value" ;;
                     FORCE_XCODE) FORCE_XCODE="$value" ;;
                     FORCE_TRASH) FORCE_TRASH="$value" ;;
                     FORCE_ICLOUD_DRIVE) FORCE_ICLOUD_DRIVE="$value" ;;
@@ -3430,6 +3433,64 @@ if run_category "31|User Tool Caches|SKIP_USER_TOOL_CACHES"; then
         fi
     else
         log "No user tool caches found"
+    fi
+    log_plain ""
+fi
+
+
+###############################################################################
+# 39. VS Code Cache
+###############################################################################
+if run_category "39|VS Code Cache|SKIP_VSCODE"; then
+
+    # VS Code writes renderer/GPU/service-worker caches under
+    # "Application Support/Code" plus a macOS-level cache under
+    # ~/Library/Caches. All of them rebuild automatically on the next
+    # VS Code launch, so clearing them is safe.
+    # STRICTLY OUT OF SCOPE (user data, never touched by this category):
+    #   - Application Support/Code/User             (settings.json,
+    #     keybindings, snippets, tasks)
+    #   - Application Support/Code/workspaceStorage (per-workspace state)
+    #   - ~/.vscode                                 (extensions)
+    # Use $USER_HOME throughout; paths contain spaces and are quoted.
+    VSCODE_DIRS=(
+        "$USER_HOME/Library/Application Support/Code/Cache"
+        "$USER_HOME/Library/Application Support/Code/CachedData"
+        "$USER_HOME/Library/Application Support/Code/Code Cache"
+        "$USER_HOME/Library/Application Support/Code/GPUCache"
+        "$USER_HOME/Library/Application Support/Code/Service Worker/CacheStorage"
+        "$USER_HOME/Library/Caches/com.microsoft.VSCode"
+    )
+
+    VSCODE_BYTES=0
+    VSCODE_HIT=0
+
+    for vscode_dir in "${VSCODE_DIRS[@]}"; do
+        if measured=$(measure_cache_dir "$vscode_dir"); then
+            bytes="${measured%%|*}"
+            human="${measured#*|}"
+            VSCODE_BYTES=$((VSCODE_BYTES + bytes))
+            VSCODE_HIT=$((VSCODE_HIT + 1))
+            log "Found VS Code cache: $human ($vscode_dir)"
+        fi
+    done
+
+    if [ "$VSCODE_HIT" -gt 0 ]; then
+        VSCODE_HUMAN=$(bytes_to_human "$VSCODE_BYTES")
+        record_category_size "VS Code Cache" "$VSCODE_BYTES" "$VSCODE_HUMAN"
+        if [ "$DRY_RUN" = true ]; then
+            log "Would clear VS Code caches: $VSCODE_HUMAN"
+            TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + VSCODE_BYTES))
+        else
+            log "Clearing VS Code caches..."
+            for vscode_dir in "${VSCODE_DIRS[@]}"; do
+                [ -d "$vscode_dir" ] && [ ! -L "$vscode_dir" ] && safe_clear_directory "$vscode_dir" 2>/dev/null || true
+            done
+            log_success "VS Code caches cleared: $VSCODE_HUMAN"
+            TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + VSCODE_BYTES))
+        fi
+    else
+        log "No VS Code caches found"
     fi
     log_plain ""
 fi

--- a/completions/_mac-cleans
+++ b/completions/_mac-cleans
@@ -55,6 +55,7 @@ _mac_cleans() {
         '--skip-jetbrains[Skip JetBrains IDE caches (IntelliJ, PyCharm, ...)]'
         '--skip-cargo[Skip Cargo registry cache]'
         '--skip-nuget[Skip NuGet package cache]'
+        '--skip-vscode[Skip VS Code cache]'
         '--skip-system-tmp[Skip /tmp and /var/tmp (default: on)]'
         '--clean-system-tmp[Opt in to /tmp and /var/tmp cleanup]'
     )

--- a/completions/mac-cleans.bash
+++ b/completions/mac-cleans.bash
@@ -22,6 +22,7 @@ _mac_cleans() {
         --skip-cargo
         --skip-gradle --skip-go --skip-bun --skip-pnpm --skip-nuget
         --skip-browser-tools --skip-crash-reports --skip-user-tool-caches
+        --skip-vscode
         --skip-system-tmp --clean-system-tmp
     )
 

--- a/completions/mac-cleans.fish
+++ b/completions/mac-cleans.fish
@@ -51,6 +51,7 @@ complete -c mac-cleans -l skip-user-tool-caches -d 'Skip user tool caches in ~/.
 complete -c mac-cleans -l skip-jvm -d 'Skip JVM build caches (Maven/Ivy/sbt)'
 complete -c mac-cleans -l skip-jetbrains -d 'Skip JetBrains IDE caches (IntelliJ, PyCharm, ...)'
 complete -c mac-cleans -l skip-cargo -d 'Skip Cargo registry cache'
+complete -c mac-cleans -l skip-vscode -d 'Skip VS Code cache'
 complete -c mac-cleans -l skip-system-tmp -d 'Skip /tmp and /var/tmp (default: on)'
 complete -c mac-cleans -l clean-system-tmp -d 'Opt in to /tmp and /var/tmp cleanup'
 

--- a/docs/reference/categories.md
+++ b/docs/reference/categories.md
@@ -40,6 +40,7 @@ Complete reference of all cleanup categories in MacCleans.
 | JetBrains IDE Caches | 1-10GB | High | `--skip-jetbrains` |
 | Cargo Registry Cache | 500MB-5GB | Low | `--skip-cargo` |
 | NuGet Package Cache | 500MB-5GB | Medium | `--skip-nuget` |
+| VS Code Cache | 200MB-2GB | Medium | `--skip-vscode` |
 | System Cache | 100MB-1GB | Low | (always safe) |
 | User Cache | 100MB-1GB | Low | (always safe) |
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -270,6 +270,7 @@ sudo Mac-Clean --yes \
   --skip-jetbrains \
   --skip-cargo \
   --skip-nuget \
+  --skip-vscode \
   --skip-system-tmp \
   --clean-system-tmp
 ```

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -54,6 +54,7 @@ CLI flags override config values. See [how-to/configure.md](../how-to/configure.
 | `SKIP_JVM` | `false` | Skip Maven / Ivy / sbt build caches. |
 | `SKIP_CARGO` | `false` | Skip Cargo registry cache (`~/.cargo/registry/{cache,src}`). |
 | `SKIP_NUGET` | `false` | Skip NuGet package cache (`~/.nuget/packages`). Packages re-download on the next `dotnet restore`. |
+| `SKIP_VSCODE` | `false` | Skip VS Code renderer/GPU/service-worker caches plus `~/Library/Caches/com.microsoft.VSCode`. Settings (`Code/User`) and extensions (`~/.vscode`) are never touched. |
 | `SKIP_SYSTEM_TMP` | `true` | Skip `/tmp` and `/var/tmp`. **Default-on** for safety; opt in with `--clean-system-tmp` or set `SKIP_SYSTEM_TMP=false`. |
 | `SKIP_JETBRAINS` | `false` | Skip JetBrains IDE caches (`~/Library/Caches/JetBrains`). Settings/plugins in Application Support are never touched. |
 

--- a/maccleans.conf.example
+++ b/maccleans.conf.example
@@ -93,3 +93,4 @@ SKIP_JVM=false                 # ~/.m2/repository, ~/.ivy2/cache, ~/.sbt/boot (r
 SKIP_JETBRAINS=false         # ~/Library/Caches/JetBrains (per-version IDE caches; rebuild on next launch)
 SKIP_CARGO=false              # ~/.cargo/registry/{cache,src} (.crate archives + extracted sources)
 SKIP_NUGET=false              # ~/.nuget/packages (NuGet global-packages folder; re-downloaded on next dotnet restore)
+SKIP_VSCODE=false              # VS Code renderer/GPU/service-worker caches + ~/Library/Caches/com.microsoft.VSCode

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -214,6 +214,21 @@ test_registry_has_jetbrains_ide_caches() {
     [ "$found_jb" -eq 1 ]
 }
 
+test_registry_has_vscode_cache() {
+    # Verify the v6.0 entry (39 VS Code Cache) exists with the right
+    # display name and skip_var wiring.
+    local entry found_vs
+    found_vs=0
+    for entry in "${CATEGORY_REGISTRY[@]}"; do
+        if [ "$(registry_get_skip_var "$entry")" = "SKIP_VSCODE" ] && [ "$(registry_get_display "$entry")" = "VS Code Cache" ]; then
+            found_vs=1
+            break
+        fi
+    done
+    [ "$found_vs" -eq 1 ]
+
+}
+
 # --- Security audit tests (added 2026-06-05) -------------------------------
 #
 # These tests codify the three rules from the security audit pass:
@@ -564,6 +579,24 @@ test_completions_include_nuget_skip_flag() {
         echo "completions/mac-cleans.fish missing -l skip-nuget" >&2
         return 1
     fi
+}
+
+test_completions_include_vscode_skip_flag() {
+    # v6.0 added --skip-vscode for the new #39 category. Without this
+    # test, a future refactor of the completion files could quietly
+    # drop the new flag (same bug class as the xcode-archives test).
+    if ! /usr/bin/grep -qF -e "--skip-vscode" "$REPO_ROOT/completions/mac-cleans.bash"; then
+        echo "completions/mac-cleans.bash missing --skip-vscode" >&2
+        return 1
+    fi
+    if ! /usr/bin/grep -qF -e "--skip-vscode" "$REPO_ROOT/completions/_mac-cleans"; then
+        echo "completions/_mac-cleans missing --skip-vscode" >&2
+        return 1
+    fi
+    if ! /usr/bin/grep -qF -e "-l skip-vscode" "$REPO_ROOT/completions/mac-cleans.fish"; then
+        echo "completions/mac-cleans.fish missing -l skip-vscode" >&2
+        return 1
+    fi
     return 0
 }
 test_completions_include_v56_skip_flags() {
@@ -764,9 +797,11 @@ assert "Completions include the 3 v5.6.0 --skip-X flags"                 test_co
 assert "Completions include the v5.8.0 --skip-xcode-archives flag"         test_completions_include_xcode_archives_skip_flag
 assert "CATEGORY_REGISTRY has Cargo Registry Cache wired to SKIP_CARGO"   test_registry_has_cargo_registry_cache
 assert "CATEGORY_REGISTRY has NuGet Package Cache entry (SKIP_NUGET)"      test_registry_has_nuget_package_cache
+assert "CATEGORY_REGISTRY has the v6.0 VS Code Cache entry"                test_registry_has_vscode_cache
 assert "Completions include the v6 --skip-jvm flag"                        test_completions_include_jvm_skip_flag
 assert "Completions include the v6 --skip-cargo flag"                     test_completions_include_cargo_skip_flag
 assert "Completions include the v6 --skip-nuget flag"                      test_completions_include_nuget_skip_flag
+assert "Completions include the v6.0 --skip-vscode flag"                   test_completions_include_vscode_skip_flag
 assert "load_config_file case statement covers every registry SKIP_X"     test_config_loader_covers_every_registry_skip_x
 assert "Interactive menu digit handler covers 1-N (no silent swallow)"    test_interactive_menu_handles_all_digit_ranges
 assert "CATEGORY_REGISTRY has the #36 JetBrains IDE Caches entry"        test_registry_has_jetbrains_ide_caches


### PR DESCRIPTION
## What

New cleanup category **#39 VS Code Cache** (`SKIP_VSCODE`, `--skip-vscode`): cleans 6 cache locations — `Application Support/Code/{Cache,CachedData,Code Cache,GPU-cache,Service Worker/CacheStorage}` and `~/Library/Caches/com.microsoft.VSCode`. Typical savings 200MB-2GB.

## Safety story

Renderer/GPU/service-worker caches rebuild on next VS Code launch. Strictly out of scope (documented in section comment + docs): `Application Support/Code/User` (settings/keybindings/snippets), `workspaceStorage`, and `~/.vscode` (extensions). All space-containing paths are quoted.

## Wiring (full registry contract)

- Registry entry `"39|VS Code Cache|SKIP_VSCODE"`, help line, config-loader case, conf.example
- Completions x3; docs: categories.md row, config-file.md, commands.md flag list
- Tests: registry-walk presence + completion parity (28/28 pass)

## Verification

- `bash -n`, `shellcheck -S warning` clean; 28/28 tests
- Behavioral review incl. fixture home with a path containing a real space: dry-run parity (`estimated_bytes` exact), real run cleared all 6 dirs while settings.json and extensions survived; symlinked cache root neither followed nor deleted

## Review gate

Scored **100/100** by two independent reviewer agents on first pass (60/60 + 40/40).

Merge order: depends on #90 (test-infra).

🧹 Clean code, clean disk

## Summary by Sourcery

Add safe, configurable cleanup of rebuildable VS Code caches across the application and macOS cache directories.

New Features:
- Add VS Code cache cleanup as category 39, covering rebuildable application and macOS cache locations while preserving settings, workspace data, and extensions.
- Expose the new cleanup option through the `--skip-vscode` flag and configuration setting.

Enhancements:
- Register the VS Code category and support its cache size reporting, dry-run accounting, and symlink-safe cleanup behavior.

Documentation:
- Document the VS Code cache category, configuration option, and command-line flag.

Tests:
- Add coverage for registry wiring and parity of the new flag across shell completion files.