### PR TITLE
feat: Docker estimated_bytes in JSON details (#12)

### DIFF
--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -2375,6 +2375,18 @@ if run_category "12|Docker Cache|SKIP_DOCKER"; then
                     DOCKER_RECLAIM=$(size_to_bytes "$DOCKER_RECLAIM_SIZE")
                 fi
 
+                # Publish the reclaimable estimate for --json details.
+                # Nesting already guarantees docker is installed, the
+                # daemon answered, and the `docker system df` call
+                # succeeded (non-empty DOCKER_INFO); the numeric guard
+                # below keeps an unexpected size string from poisoning
+                # TOTAL_BYTES_FREED (size_to_bytes maps garbage to 0,
+                # and `2>/dev/null` silences the integer test's
+                # non-numeric complaint under set -e).
+                if [ -n "${DOCKER_RECLAIM:-}" ] && [ "$DOCKER_RECLAIM" -gt 0 ] 2>/dev/null; then
+                    record_category_size "Docker Cache" "$DOCKER_RECLAIM" "$DOCKER_RECLAIM_SIZE"
+                fi
+
                 if [ "$DRY_RUN" = true ]; then
                     log "Would clean Docker cache (dangling images, stopped containers, unused networks)"
                     TOTAL_BYTES_FREED=$((TOTAL_BYTES_FREED + DOCKER_RECLAIM))

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -805,6 +805,44 @@ test_user_home_derivation_uses_sudo_user() {
     return 0
 }
 
+
+test_docker_records_category_size() {
+    # Source-text audit (same style as test_user_home_derivation_uses_sudo_user):
+    # the Docker section (#12) must publish its reclaimable estimate via
+    # record_category_size so the --json "details" object gains
+    # estimated_bytes / estimated_human for "Docker Cache" -- closing the
+    # gap documented in CHANGELOG [5.8.0] ("#12 Docker only has
+    # reclaimable"). The call must be guarded by a successful df /
+    # measured condition: docker available, daemon up, non-empty
+    # `docker system df` output, and a parsed byte count > 0. This test
+    # never executes the script and never requires docker.
+    local docker_block
+    docker_block=$(/usr/bin/awk '/run_category "12[|]Docker Cache/ {on=1}
+                               /run_category "13[|]iOS Simulator Data/ {on=0}
+                               on' "$SCRIPT_PATH")
+
+    if [ -z "$docker_block" ]; then
+        echo "Could not extract Docker section from clean-mac-space.sh" >&2
+        return 1
+    fi
+    if ! echo "$docker_block" | /usr/bin/grep -qF 'record_category_size "Docker Cache"'; then
+        echo 'Docker section does not call record_category_size "Docker Cache":' >&2
+        echo "$docker_block" >&2
+        return 1
+    fi
+    if ! echo "$docker_block" | /usr/bin/grep -qE 'DOCKER_RECLAIM.*-gt 0'; then
+        echo "Docker record_category_size call is not guarded by a measured DOCKER_RECLAIM > 0:" >&2
+        echo "$docker_block" >&2
+        return 1
+    fi
+    if ! echo "$docker_block" | /usr/bin/grep -qF 'size_to_bytes'; then
+        echo "Docker section does not convert the reclaimable size with size_to_bytes:" >&2
+        echo "$docker_block" >&2
+        return 1
+    fi
+    return 0
+}
+
 # --- Run -------------------------------------------------------------------
 
 echo "Running smoke tests for clean-mac-space.sh helpers..."
@@ -846,6 +884,7 @@ assert "--list-categories handled in parse_arguments + all completions"      tes
 assert "Interactive menu digit handler covers 1-N (no silent swallow)"    test_interactive_menu_handles_all_digit_ranges
 assert "CATEGORY_REGISTRY has the #36 JetBrains IDE Caches entry"        test_registry_has_jetbrains_ide_caches
 assert "Completions include the v6 --skip-jetbrains flag"                test_completions_include_jetbrains_skip_flag
+assert "Docker section records estimated_bytes via record_category_size (source-text audit)" test_docker_records_category_size
 
 TOTAL=$(( PASS + FAIL ))
 echo ""


### PR DESCRIPTION
## What

Populates `estimated_bytes` / `estimated_human` for category **#12 Docker Cache** in the `--json` details output via the existing `record_category_size` helper — closing the gap documented in the v5.8.0 changelog ("#12 Docker only has reclaimable").

## Implementation notes

- After the existing `docker system df --format` call yields reclaimable size, it's converted with `size_to_bytes` and recorded; display logic is byte-identical
- Guarded: only records when docker is available, the df call succeeded, and bytes parse > 0 — garbage strings map to 0 and can never poison `TOTAL_BYTES_FREED` or crash under `set -euo pipefail`
- Call sits before the DRY_RUN branch, so dry-run/real-run parity matches the Mail App Cache exemplar
- New mutation-verified source-audit test (27/27 pass)

## Verification

- `bash -n`, `shellcheck -S warning` clean; 27/27 tests
- Reviewer ran live sudo dry-runs with a stubbed docker binary: valid JSON with correct estimated_bytes/human for measured, skipped (`--skip-docker`), and not-installed paths

## Review gate

Scored **100/100** by two independent reviewer agents on first pass (60/60 + 40/40).

🧹 Clean code, clean disk

## Summary by Sourcery

Expose Docker Cache reclaimable estimates in JSON category details while preserving safe behavior for unavailable or invalid Docker data.

New Features:
- Populate Docker Cache JSON details with reclaimable byte estimates and human-readable sizes when valid Docker usage data is available.

Tests:
- Add a source-audit test verifying Docker estimate recording, size conversion, and positive-value guarding.