### PR TITLE
chore: release v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to MacCleans.sh are documented in this file.
 
 ## [Unreleased]
 
+## [6.0.0] - 2026-08-21
+
+### Added
+
+- **New cleanup category #35: JVM Build Caches** — clears `~/.m2/repository` (Maven), `~/.ivy2/cache` (Ivy), and `~/.sbt/boot` (sbt). Typically 500MB-5GB; everything re-downloads from Maven Central on the next build. Gradle remains covered separately by category #24. Gated by `--skip-jvm` / `SKIP_JVM`.
+- **New cleanup category #36: JetBrains IDE Caches** — clears per-version cache directories under `~/Library/Caches/JetBrains` (IntelliJ IDEA, PyCharm, WebStorm, GoLand, CLion, RubyMine, PhpStorm, Android Studio). Typically 1-10GB across IDE upgrades and never cleaned automatically. Strictly out of scope: `~/Library/Application Support/JetBrains` (IDE settings + plugins) and `~/Library/Logs/JetBrains`. Note that clearing the Caches tree also drops JetBrains Local History (uncommitted-change history); the first launch after cleaning re-indexes open projects. Gated by `--skip-jetbrains` / `SKIP_JETBRAINS`.
+- **New cleanup category #37: Cargo Registry Cache** — clears `~/.cargo/registry/cache/` (downloaded .crate archives) and `~/.cargo/registry/src/` (extracted sources). The registry index, `~/.cargo/bin`, `config.toml`, and `~/.rustup` are never touched; crates re-download and re-extract on the next cargo build. Gated by `--skip-cargo` / `SKIP_CARGO`.
+- **New cleanup category #38: NuGet Package Cache** — clears the NuGet package caches. Packages re-download from nuget.org on the next restore/build. Gated by `--skip-nuget` / `SKIP_NUGET`.
+- **New cleanup category #39: VS Code Cache** — clears VS Code's regenerable cache directories (CachedData, Code Cache, GPUCache, logs, service Worker CacheStorage). Workspace storage, user settings, keybindings, snippets, and extensions are strictly out of scope. Gated by `--skip-vscode` / `SKIP_VSCODE`.
+- **New `--list-categories` flag** — prints the full category table (ID, name, skip flag) derived directly from `CATEGORY_REGISTRY`, so it can never drift from the registry. Informational only: no sudo, no disk access.
+- **`--json` `details` now carries `estimated_bytes` for the Docker section (#12)** — closes the last documented gap in machine-readable size reporting alongside the existing special cases (Time Machine, iOS Simulator, Photos, iCloud Drive).
+- **Five new regression tests** covering each new category's registry wiring and completion parity (`test_registry_has_{jvm,jetbrains,cargo,nuget,vscode}…`, `test_completions_include_…_skip_flag`), plus a lower-bound relaxation of the registry-count assert so parallel category additions can't collide.
+
 ## [5.8.0] - 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ sudo Mac-Clean --yes
 
 | | | |
 |----------|----------|----------|
-| Safe by design | 32 categories | Interactive mode |
+| Safe by design | 39 categories | Interactive mode |
 | Profile presets | JSON output | CI/CD ready |
 
 ---

--- a/clean-mac-space.sh
+++ b/clean-mac-space.sh
@@ -10,7 +10,7 @@
 # Enable strict error handling
 set -euo pipefail
 
-VERSION="5.8.0"
+VERSION="6.0.0"
 
 ###############################################################################
 # Mac-Clean: macOS Disk Cleanup Utility

--- a/installer.sh
+++ b/installer.sh
@@ -12,7 +12,7 @@ INSTALL_DIR="/usr/local/bin"
 SCRIPT_NAME="Mac-Clean"
 GITHUB_RAW_URL="https://raw.githubusercontent.com/Carme99/MacCleans.sh/main/clean-mac-space.sh"
 INSTALL_PATH="${INSTALL_DIR}/${SCRIPT_NAME}"
-EXPECTED_HASH="fc9543d25841f556d05558761df58631f2d28d6a6bb3609b84036d1fd1d845f8"
+EXPECTED_HASH="5522576b067a5144ad559fb3ccd792558dd98cdd7a43cdcb6e98a509e86ddfb3"
 
 # Colors
 RED='\033[0;31m'


### PR DESCRIPTION
## Release prep for v6.0.0

Follows the merged V6 feature train (#90–#97): 5 new cache categories (#35 JVM, #36 JetBrains, #37 Cargo, #38 NuGet, #39 VS Code), the `--list-categories` flag, and Docker `estimated_bytes` in JSON details.

### Changes
- `clean-mac-space.sh`: `VERSION` 5.8.0 → **6.0.0** (via `scripts/release.sh 6.0.0`)
- `installer.sh`: `EXPECTED_HASH` regenerated to match (SHA-256 verified by the script)
- `CHANGELOG.md`: `[Unreleased]` folded into **[6.0.0] — 2026-08-21** with entries for all seven features
- `README.md`: features-table badge 32 → **39 categories**

### Verification
- `scripts/release.sh 6.0.0` sanity gate: bash -n, shellcheck, `--version` reports `MacCleans v6.0.0`
- Full test suite: 37/37 passing on this branch
- Tagging happens after merge: tag will point at the merge commit on `main`.

## Summary by Sourcery

Prepare MacCleans for the v6.0.0 release with the latest cleanup capabilities, documentation, and release metadata.

Enhancements:
- Update the project for the v6.0.0 release, including five additional cleanup categories, category listing, and Docker size details in JSON output.

Documentation:
- Publish the v6.0.0 changelog and update the README to reflect 39 cleanup categories.

Tests:
- Document the regression coverage for the five new categories and their completion flags.

Chores:
- Update the utility version and installer verification hash for v6.0.0.