### PR TITLE
docs: post-v6.0.0 documentation sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ sudo Mac-Clean --yes
 | Browser Testing Tool Caches | 500MB-2GB | Re-downloaded on next test |
 | Crash Reports | 100MB-1GB | Old crash dumps (>7 days) |
 | User Tool Caches | 500MB-2GB | `~/.cache/` redownloads on demand |
-| +20 more | | [See all categories](docs/reference/categories.md) |
+| +26 more (incl. JVM, JetBrains, Cargo, NuGet, VS Code caches) | | [See all categories](docs/reference/categories.md) |
 
 ---
 

--- a/docs/contributing/developer-guide.md
+++ b/docs/contributing/developer-guide.md
@@ -6,7 +6,7 @@ Interested in contributing to MacCleans? This guide covers everything you need t
 
 ```mermaid
 sequenceDiagram
-    participant CR as CATEGORY_REGISTRY (30 entries)
+    participant CR as CATEGORY_REGISTRY (39 entries)
     participant ID as registry_get_skip_var
     participant ID2 as registry_get_display
     participant Init as _init_skip_defaults
@@ -100,7 +100,7 @@ There is intentionally **no `tests/` directory and no `npm test`** — MacCleans
 10. **Disk / size helpers** — `safe_du`, `size_to_bytes`, `bytes_to_human`, `check_disk_space`, `check_minimum_disk_space` (lines ~846-925)
 11. **Health checks** — `perform_health_checks` (line 1031)
 12. **Profile loader** — `load_profile` (line 1071)
-13. **Category cleanup sections** — 30 top-level procedural blocks, numbered #1 through #28 continuously plus 3a (Spotify Cache) and 3b (Claude Desktop Cache) sub-numbered; 30 total entries in `CATEGORY_REGISTRY` (the F-2 numbering gap that was noted in the v5.2.0 review was fixed in v5.4.0; the root-cause refactor into a `CATEGORY_REGISTRY` + `run_category` dispatcher is F-5, shipped in v5.5.0)
+13. **Category cleanup sections** — 39 registry entries, numbered #1 through #31 continuously (including 3a Spotify Cache and 3b Claude Desktop Cache sub-numbered) plus #34–#39 (Xcode Archives, JVM, JetBrains, Cargo, NuGet, VS Code); 39 total entries in `CATEGORY_REGISTRY` (the F-2 numbering gap that was noted in the v5.2.0 review was fixed in v5.4.0; the root-cause refactor into a `CATEGORY_REGISTRY` + `run_category` dispatcher is F-5, shipped in v5.5.0; the count test is a lower-bound assert since v6.0.0 so parallel category additions can't collide)
 14. **JSON output** (the trailing `# Deliver results as JSON` block)
 
 ## Adding a New Category

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -95,5 +95,5 @@ Say PR #83 is a `fix:` for a Photos Library edge case:
 |---|---|---|
 | `scripts/release.sh` refuses to run | Not on `main` | `git checkout main` |
 | Workflow fails with "couldn't compute sha256" | Tarball URL changed or GITHUB_REF_NAME is wrong | Check the [release workflow debugging notes](https://github.com/Carme99/MacCleans.sh/blob/main/.github/workflows/release.yml) |
-| Homebrew tap formula is wrong after release | Token (`HOMEBREW_TAP_TOKEN`) lost or rotated | See [CONTRIBUTING.md § One-time setup for the maintainer](../CONTRIBUTING.md#one-time-setup-for-the-maintainer) |
+| Homebrew tap formula is wrong after release | Token (`HOMEBREW_TAP_TOKEN`) lost or rotated | See [CONTRIBUTING.md § One-time setup for the maintainer](../../CONTRIBUTING.md#one-time-setup-for-the-maintainer) |
 | Want to undo a release | Tag was pushed but the tap/release is bad | Delete tag locally + on origin, fix the issue, re-tag. `git push origin :refs/tags/v5.5.3` to delete remotely. |

--- a/docs/explanation/faq.md
+++ b/docs/explanation/faq.md
@@ -127,7 +127,7 @@ It's completely offline and private.
 ### Q: Can I audit the code?
 
 **A:** Yes! The entire script is open-source. You can:
-- Read the source code: [clean-mac-space.sh](clean-mac-space.sh)
+- Read the source code: [clean-mac-space.sh](../../clean-mac-space.sh)
 - Review on GitHub: [Carme99/MacCleans.sh](https://github.com/Carme99/MacCleans.sh)
 - Run ShellCheck on it yourself
 - Inspect every command before running

--- a/docs/explanation/how-it-works.md
+++ b/docs/explanation/how-it-works.md
@@ -36,8 +36,8 @@ sequenceDiagram
 ```
 
 The script is one bash file (`clean-mac-space.sh`) with a top-level
-`CATEGORY_REGISTRY` array of 30 entries (1-28 numbered + 3a Spotify + 3b
-Claude). Every consumer — default skip-flag init, the section body dispatcher,
+`CATEGORY_REGISTRY` array of 39 entries (1-31 numbered + 3a Spotify + 3b
+Claude Desktop + 34-39 for the newer dev-tool caches). Every consumer — default skip-flag init, the section body dispatcher,
 `--skip-X` argument parsing, config validation, the interactive menu — reads
 from that one array. Adding a category = one new line in the registry + one
 new section body.

--- a/docs/how-to/configure.md
+++ b/docs/how-to/configure.md
@@ -66,10 +66,19 @@ SKIP_GRADLE=false
 SKIP_GO=false
 SKIP_BUN=false
 SKIP_PNPM=false
+SKIP_BROWSER_TOOLS=false
+SKIP_CRASH_REPORTS=false
+SKIP_USER_TOOL_CACHES=false
+SKIP_XCODE_ARCHIVES=false
+SKIP_JVM=false
+SKIP_JETBRAINS=false
+SKIP_CARGO=false
+SKIP_NUGET=false
+SKIP_VSCODE=false
 SKIP_SYSTEM_TMP=true
 ```
 
-A complete, commented-out example is also available at the repo root as [`maccleans.conf.example`](../maccleans.conf.example) — copy it to one of the locations above and edit.
+A complete, commented-out example is also available at the repo root as [`maccleans.conf.example`](../../maccleans.conf.example) — copy it to one of the locations above and edit.
 
 ## All Configuration Options
 
@@ -110,6 +119,15 @@ Set to `true` to skip a category during cleanup.
 | `SKIP_ICLOUD_MAIL` | iCloud Mail cache |
 | `SKIP_PHOTOS_LIBRARY` | Photos library cache |
 | `SKIP_ICLOUD_DRIVE` | iCloud Drive offline files |
+| `SKIP_BROWSER_TOOLS` | Browser testing tool caches |
+| `SKIP_CRASH_REPORTS` | Crash reports |
+| `SKIP_USER_TOOL_CACHES` | User tool caches (`~/.cache/...`) |
+| `SKIP_XCODE_ARCHIVES` | Xcode archives (requires `--force-xcode`) |
+| `SKIP_JVM` | JVM build caches (Maven, Ivy, sbt) |
+| `SKIP_JETBRAINS` | JetBrains IDE caches |
+| `SKIP_CARGO` | Cargo registry cache |
+| `SKIP_NUGET` | NuGet package cache |
+| `SKIP_VSCODE` | VS Code cache |
 | `SKIP_QUICKLOOK` | QuickLook thumbnails |
 | `SKIP_DIAGNOSTICS` | Diagnostic reports |
 | `SKIP_IOS_BACKUPS` | iOS device backups |

--- a/docs/how-to/guides/docker-cache.md
+++ b/docs/how-to/guides/docker-cache.md
@@ -233,23 +233,25 @@ docker system prune -a --volumes
 **MacCleans equivalent**:
 ```bash
 sudo ./clean-mac-space.sh --profile aggressive
-# Includes Docker cleanup (safe version - no volumes by default)
+# Includes Docker cleanup (safe version — named volumes are never touched)
 ```
 
 ## Safe Docker Cleanup (MacCleans Approach)
 
-MacCleans uses this command:
+MacCleans uses these commands:
 
 ```bash
-docker system prune -af --volumes
+docker container prune -f
+docker image prune -f
 ```
 
-**Flags explained**:
-- `-a`: Remove all unused images (not just dangling)
-- `-f`: Force (no confirmation prompt)
-- `--volumes`: Remove unused volumes
+**What each does**:
+- `container prune`: Removes stopped containers
+- `image prune`: Removes dangling images (untagged intermediate layers)
 
-**Why it's safer**: MacCleans only runs if Docker command exists + user didn't skip
+**What it never touches**: Named volumes are preserved — MacCleans prints a reminder and leaves `docker volume prune` to you. Build cache and unused networks are also left alone.
+
+**Why it's safer**: MacCleans only runs if Docker is installed, the daemon is answering, and you didn't pass `--skip-docker`
 
 **How to skip it**:
 ```bash
@@ -598,9 +600,8 @@ A: `-a` removes all unused images, not just "dangling" ones (untagged). More agg
 
 **Q: Why is my Docker.raw file so large?**
 A: Docker Desktop on Mac uses a VM. The disk image grows but doesn't auto-shrink. Run cleanup or resize in settings.
-
 **Q: Should I exclude volumes from MacCleans cleanup?**
-A: MacCleans includes `--volumes` but only deletes **unused** volumes. Still, review with `docker volume ls` first.
+A: No need — MacCleans never touches volumes. It prunes only stopped containers and dangling images; run `docker volume prune` manually if you want to reclaim volume space.
 
 **Q: How do I shrink Docker.raw after cleanup?**
 A: Docker Desktop → Preferences → Resources → Disk image size → Click "Optimize disk image"

--- a/docs/how-to/guides/understanding-macos-caches.md
+++ b/docs/how-to/guides/understanding-macos-caches.md
@@ -137,6 +137,27 @@ Cache files are like keeping frequently-used ingredients in your kitchen instead
 - Development containers need recreation
 - Production: Always pull from registry anyway
 
+#### Language & IDE Tool Caches
+**Locations**:
+- JVM builds: `~/.m2/repository`, `~/.ivy2/cache`, `~/.sbt/boot`
+- JetBrains IDEs: `~/Library/Caches/JetBrains`
+- Cargo: `~/.cargo/registry`
+- NuGet: `~/.nuget/packages`
+- VS Code: `~/Library/Caches/com.microsoft.VSCode`
+
+**What they store**:
+- Downloaded package archives and extracted sources
+- Per-version IDE indexes and caches
+- Editor GPU/service-worker caches
+
+**Size**: 500MB - 10GB+ combined for polyglot developers
+
+**Safe to delete?** ✅ Yes
+
+**Impact of deletion**:
+- Next build or restore re-downloads dependencies from the registry
+- IDEs rebuild their caches on next launch
+
 ### 5. Mail Cache
 
 **Location**: `~/Library/Caches/com.apple.mail`

--- a/docs/how-to/guides/xcode-derived-data.md
+++ b/docs/how-to/guides/xcode-derived-data.md
@@ -105,8 +105,8 @@ Corrupted index or stale build artifacts can cause bizarre behavior. Clean slate
 
 **How to clean**:
 ```bash
-# MacCleans
-sudo ./clean-mac-space.sh --profile developer --skip-all-but-xcode
+# MacCleans cleans Derived Data by default (preview first with --dry-run)
+sudo ./clean-mac-space.sh --dry-run
 
 # Or manually
 rm -rf ~/Library/Developer/Xcode/DerivedData

--- a/docs/how-to/profiles.md
+++ b/docs/how-to/profiles.md
@@ -57,6 +57,8 @@ sudo Mac-Clean --profile developer --yes
 - Docker
 - Browser caches
 - iOS Simulator
+- Dev-tool caches (JVM build, JetBrains IDEs, Cargo, NuGet, VS Code)
+- Browser testing tool caches
 - iOS/iPadOS Update Files
 - Everything else
 

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -410,7 +410,7 @@ du -sh ~/.npm/
 
 **Solution 2**: Use number shortcuts instead of arrows
 ```bash
-# Press 1-13 to toggle categories
+# Press 1-36 to toggle categories
 # Press 'd' when done
 ```
 

--- a/docs/reference/categories.md
+++ b/docs/reference/categories.md
@@ -36,6 +36,7 @@ Complete reference of all cleanup categories in MacCleans.
 | Browser Testing Tool Caches | 500MB-2GB | Low | `--skip-browser-tools` |
 | Crash Reports | 100MB-1GB | Low | `--skip-crash-reports` |
 | User Tool Caches | 500MB-2GB | Low | `--skip-user-tool-caches` |
+| Xcode Archives | 5-20GB | High | `--skip-xcode-archives` |
 | JVM Build Caches | 500MB-5GB | Medium | `--skip-jvm` |
 | JetBrains IDE Caches | 1-10GB | High | `--skip-jetbrains` |
 | Cargo Registry Cache | 500MB-5GB | Low | `--skip-cargo` |
@@ -557,6 +558,30 @@ sudo Mac-Clean --yes --skip-user-tool-caches
 ```
 
 ---
+
+### Xcode Archives
+
+**Path:** `~/Library/Developer/Xcode/Archives`
+
+**Typical Size:** 5-20GB on a Mac with any iOS/macOS development history
+
+**What it does:** Deletes archived app builds (`.xcarchive` bundles). Each archive holds a release build plus its dSYMs.
+
+**What it doesn't do:** Unlike DerivedData, archives are NOT regenerated. Recovery requires a backup.
+
+**Risk:** High - release builds and debug symbols cannot be re-created once deleted
+
+**When to skip:** Unless you are certain you won't need any archived builds
+
+**Requires:** `--force-xcode` to delete without the interactive prompt (same gate as Xcode Derived Data)
+
+```bash
+# Skip Xcode Archives
+sudo Mac-Clean --yes --skip-xcode-archives
+```
+
+---
+
 ### Cargo Registry Cache
 
 **Paths:** `~/.cargo/registry/cache`, `~/.cargo/registry/src`
@@ -633,6 +658,28 @@ sudo Mac-Clean --yes --skip-jetbrains
 ```bash
 # Skip NuGet package cache
 sudo Mac-Clean --yes --skip-nuget
+```
+
+---
+
+### VS Code Cache
+
+**Paths:**
+- `~/Library/Application Support/Code/Cache`, `CachedData`, `Code Cache`, `GPUCache`
+- `~/Library/Application Support/Code/Service Worker/CacheStorage`
+- `~/Library/Caches/com.microsoft.VSCode`
+
+**Typical Size:** 200MB-2GB
+
+**What it does:** VS Code's regenerable caches: renderer bytecode caches, GPU cache, service-worker cache storage, and the macOS-level app cache. Everything rebuilds automatically on the next launch.
+
+**What it doesn't delete:** Settings (`Code/User`), extensions (`~/.vscode`), and per-workspace state (`workspaceStorage`).
+
+**Risk:** Medium - safe to delete, but the first launch afterwards is slower while caches rebuild
+
+```bash
+# Skip VS Code cache
+sudo Mac-Clean --yes --skip-vscode
 ```
 
 ---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -125,7 +125,7 @@ sudo Mac-Clean --dry-run --json
 **Example output:**
 ```json
 {
-  "version": "5.7.0",
+  "version": "6.0.0",
   "timestamp": "2026-06-05T18:30:00Z",
   "dry_run": true,
   "results": {
@@ -183,9 +183,12 @@ sudo Mac-Clean --dry-run --json | jq '[.results.categories.details | to_entries[
 
 Note: `estimated_bytes` / `estimated_human` are populated only for
 categories whose section body calls `record_category_size`. As of
-v5.7.0, that's categories #29 (Browser Testing Tool Caches), #30
-(Crash Reports), and #31 (User Tool Caches). Other categories still
-appear in `details` with just `status` and `skip_flag`.
+v6.0.0 most categories report them — including Docker (#12), which
+previously had no estimate. A few special cases still appear in
+`details` with just `status` and `skip_flag` (for example Time
+Machine Local Snapshots, Photos Library, iCloud Drive, and Xcode
+Archives); Docker and iOS Simulator report a size only when one can
+be measured.
 
 ---
 
@@ -267,6 +270,7 @@ sudo Mac-Clean --yes \
   --skip-browser-tools \
   --skip-crash-reports \
   --skip-user-tool-caches \
+  --skip-xcode-archives \
   --skip-jvm \
   --skip-jetbrains \
   --skip-cargo \

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -51,6 +51,10 @@ CLI flags override config values. See [how-to/configure.md](../how-to/configure.
 | `SKIP_GO` | `false` | Skip Go module cache. |
 | `SKIP_BUN` | `false` | Skip Bun cache. |
 | `SKIP_PNPM` | `false` | Skip pnpm store. |
+| `SKIP_BROWSER_TOOLS` | `false` | Skip browser testing tool caches (`~/.cache/puppeteer`, `~/.cache/selenium`). |
+| `SKIP_CRASH_REPORTS` | `false` | Skip crash report cleanup (deletes dumps older than 7 days). |
+| `SKIP_XCODE_ARCHIVES` | `false` | Skip Xcode archives (`~/Library/Developer/Xcode/Archives`; release builds + dSYMs, not regenerated). Deletion also requires `FORCE_XCODE`. |
+| `SKIP_USER_TOOL_CACHES` | `false` | Skip CLI tool caches under `~/.cache` (uv, giget, gh, starship, etc.). |
 | `SKIP_JVM` | `false` | Skip Maven / Ivy / sbt build caches. |
 | `SKIP_CARGO` | `false` | Skip Cargo registry cache (`~/.cargo/registry/{cache,src}`). |
 | `SKIP_NUGET` | `false` | Skip NuGet package cache (`~/.nuget/packages`). Packages re-download on the next `dotnet restore`. |
@@ -77,7 +81,7 @@ These exist to bypass per-operation safety gates without enabling global `--forc
 
 | Key | Default | Effect |
 |---|---|---|
-| `FORCE_XCODE` | `false` | Allow Xcode derived data deletion without `--force`. |
+| `FORCE_XCODE` | `false` | Allow Xcode derived data and Xcode archives deletion without `--force`. |
 | `FORCE_TRASH` | `false` | Allow trash emptying without `--force`. |
 | `FORCE_ICLOUD_DRIVE` | `false` | Allow iCloud Drive offline files deletion (bypasses sync). |
 | `FORCE_IOS_BACKUPS` | `false` | Allow iOS device backups deletion (requires iCloud backup enabled). |

--- a/docs/tutorials/first-cleanup.md
+++ b/docs/tutorials/first-cleanup.md
@@ -8,7 +8,7 @@ A 30-second walkthrough of running MacCleans for the first time. You'll preview 
 sudo Mac-Clean --dry-run
 ```
 
-You'll see each of the 30 cleanup categories in turn. `--dry-run` is harmless — no files are touched. It also pre-flight checks disk space, sudo, iCloud config, and skips anything you've disabled.
+You'll see each of the 39 cleanup categories in turn. `--dry-run` is harmless — no files are touched. It also pre-flight checks disk space, sudo, iCloud config, and skips anything you've disabled.
 
 ```text
 ================================================
@@ -52,7 +52,7 @@ Sample `--json` output:
 
 ```json
 {
-  "version": "5.7.0",
+  "version": "6.0.0",
   "timestamp": "2026-06-05T18:30:00Z",
   "dry_run": true,
   "results": {


### PR DESCRIPTION
Post-release doc sweep against v6.0.0.

- **reference**: #34 Xcode Archives + #39 VS Code Cache sections; JSON examples to `6.0.0`; `--skip-xcode-archives` in flag list; Docker `estimated_bytes` gap-closed note; 4 missing SKIP_* config keys; FORCE_XCODE scope widened
- **tutorials/how-to**: category counts 30→39, interactive toggle range 1-36 (verified: 39 entries − 3 always-run), #35–#39 in profiles/guides/configure tables, stale 5.7.0 JSON examples
- **explanation/contributing**: CATEGORY_REGISTRY 30→39 in prose + mermaid participant label
- **README**: '+20 more' → '+26 more' with new categories named
- 3 broken relative links fixed
- All 7 mermaid diagrams render-validated with mmdc (chrome-headless-shell); relative-link audit clean

## Summary by Sourcery

Bring the documentation in line with the v6.0.0 cleanup categories, configuration options, safety behavior, and output format.

New Features:
- Add reference documentation for Xcode Archives and VS Code caches, including cleanup risks, paths, and skip options.
- Document the newly available development-tool cache categories and their configuration keys across tutorials, profiles, and guides.

Bug Fixes:
- Correct broken relative links in the FAQ, configuration guide, and release process documentation.
- Update Docker cleanup guidance to accurately describe volume preservation and current pruning behavior.

Enhancements:
- Refresh category counts, interactive menu ranges, registry descriptions, README category totals, and v6.0.0 JSON examples throughout the documentation.
- Clarify Docker size reporting coverage and widen FORCE_XCODE documentation to include Xcode Archives.

Documentation:
- Synchronize user-facing documentation with the v6.0.0 category set and behavior.